### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ git clone https://github.com/glikely/obs-ptz
 
 ```
 cd obs-studio
-git am < UI/frontend-plugins/patches/0001-Add-obs-ptz-plugin-to-OBS-Studio.patch
+git am < UI/frontend-plugins/obs-ptz/patches/0001-Add-obs-ptz-plugin-to-OBS-Studio.patch
 ```
 
 - Rebuild OBS Studio

--- a/ptz-visca.hpp
+++ b/ptz-visca.hpp
@@ -143,7 +143,7 @@ public:
 	ViscaCmd(const char *cmd_hex, QList<visca_encoding*> args, QList<visca_encoding*> rslts) :
 		cmd(QByteArray::fromHex(cmd_hex)), args(args), results(rslts) { }
 	void encode(QList<int> arglist) {
-		for (int i = 0; i < arglist.size(), i < args.size(); i++)
+		for (int i = 0; i < arglist.size() && i < args.size(); i++)
 			args[i]->encode(cmd, arglist[i]);
 	}
 	void decode(QObject *target, QByteArray msg) {


### PR DESCRIPTION
I found some typos. Would you consider to fix them?
- README.md: A path to the patch file looks incorrect when following the steps.
- ptz-visca.hpp: Comparisons are concatenated by `,`. I think it should be `&&` instead.