### PR TITLE
Adding configurable baud rate

### DIFF
--- a/ptz-device.hpp
+++ b/ptz-device.hpp
@@ -10,6 +10,8 @@
 #include <QObject>
 #include <QStringListModel>
 #include <QtGlobal>
+#include <QSerialPortInfo>
+#include <QSerialPort>
 #include <obs.hpp>
 #include <obs-frontend-api.h>
 
@@ -17,6 +19,8 @@ extern int ptz_debug_level;
 #define ptz_debug(format, ...) \
 	blog(ptz_debug_level, "%s():%i: " format, __FUNCTION__, __LINE__, \
 	##__VA_ARGS__)
+
+const QList<QSerialPort::BaudRate> common_baud_rates({ QSerialPort::Baud2400, QSerialPort::Baud38400, QSerialPort::Baud4800, QSerialPort::Baud9600, QSerialPort::Baud115200 });
 
 class PTZListModel : public QAbstractListModel {
 	Q_OBJECT

--- a/ptz-pelco-p.hpp
+++ b/ptz-pelco-p.hpp
@@ -25,7 +25,6 @@ private:
 	static std::map<QString, PelcoPUART*> interfaces;
 
 	QString port_name;
-	qint32 baud_rate;
 	QSerialPort uart;
 	QByteArray rxbuffer;
 
@@ -35,8 +34,9 @@ signals:
 	void receive(const QByteArray& packet);
 
 public:
+	QSerialPort::BaudRate baud_rate = QSerialPort::Baud9600;
 
-	PelcoPUART(QString& port_name, qint32 baudrate = 9600);
+	PelcoPUART(QString& port_name, QSerialPort::BaudRate baudrate = QSerialPort::Baud9600);
 	void open();
 	void close();
 	void send(const QByteArray& packet);
@@ -45,7 +45,7 @@ public:
 
 
 	static PelcoPUART* get_interface(QString port_name);
-	static PelcoPUART* add_interface(QString port_name, qint32 baudrate = 9600);
+	static PelcoPUART* add_interface(QString port_name, QSerialPort::BaudRate baudrate = QSerialPort::Baud9600);
 
 public slots:
 	void poll();

--- a/ptz-visca.cpp
+++ b/ptz-visca.cpp
@@ -517,7 +517,7 @@ void PTZVisca::memory_recall(int i)
 /*
  * VISCA over serial UART implementation
  */
-ViscaUART::ViscaUART(QString &port_name) : port_name(port_name)
+ViscaUART::ViscaUART(QString &port_name, QSerialPort::BaudRate baud_rate) : port_name(port_name), baud_rate(baud_rate)
 {
 	connect(&uart, &QSerialPort::readyRead, this, &ViscaUART::poll);
 	open();
@@ -528,7 +528,7 @@ void ViscaUART::open()
 	camera_count = 0;
 
 	uart.setPortName(port_name);
-	uart.setBaudRate(9600);
+	uart.setBaudRate(baud_rate);
 	if (!uart.open(QIODevice::ReadWrite)) {
 		blog(LOG_INFO, "VISCA Unable to open UART %s", qPrintable(port_name));
 		return;
@@ -596,14 +596,14 @@ void ViscaUART::poll()
 	}
 }
 
-ViscaUART * ViscaUART::get_interface(QString port_name)
+ViscaUART * ViscaUART::get_interface(QString port_name, QSerialPort::BaudRate baud_rate)
 {
 	ViscaUART *iface;
 	ptz_debug("Looking for UART object %s", qPrintable(port_name));
 	iface = interfaces[port_name];
 	if (!iface) {
 		ptz_debug("Creating new VISCA object %s", qPrintable(port_name));
-		iface = new ViscaUART(port_name);
+		iface = new ViscaUART(port_name, baud_rate);
 		interfaces[port_name] = iface;
 	}
 	return iface;
@@ -647,9 +647,20 @@ void PTZViscaSerial::set_config(OBSData config)
 	PTZDevice::set_config(config);
 	const char *uart = obs_data_get_string(config, "port");
 	address = obs_data_get_int(config, "address");
+	QSerialPort::BaudRate baudRate = (QSerialPort::BaudRate)obs_data_get_int(config, "baud_rate");
 	if (!uart)
 		return;
-	attach_interface(ViscaUART::get_interface(uart));
+
+	iface = ViscaUART::get_interface(uart);
+
+	//Settings can only be changed if the serial connection is closed;
+	if (iface->baud_rate != baudRate){
+		iface->close();
+		iface->baud_rate = (QSerialPort::BaudRate)baudRate;
+		iface->open();
+	}
+
+	attach_interface(iface);
 }
 
 OBSData PTZViscaSerial::get_config()
@@ -657,6 +668,7 @@ OBSData PTZViscaSerial::get_config()
 	OBSData config = PTZDevice::get_config();
 	obs_data_set_string(config, "port", qPrintable(iface->portName()));
 	obs_data_set_int(config, "address", address);
+	obs_data_set_int(config, "baud_rate", iface->baud_rate);
 	return config;
 }
 
@@ -674,6 +686,14 @@ obs_properties_t *PTZViscaSerial::get_obs_properties()
 		obs_property_list_add_string(p, name.c_str(), name.c_str());
 	}
 	obs_properties_add_int(config, "address", "VISCA ID", 1, 7, 1);
+
+	p = obs_properties_add_list(config, "baud_rate", "Baud Rate", OBS_COMBO_TYPE_LIST,
+		OBS_COMBO_FORMAT_INT);
+	for(QSerialPort::BaudRate baud_rate : common_baud_rates) {
+		std::string baud_rate_string = std::to_string(baud_rate);
+		obs_property_list_add_int(p, baud_rate_string.c_str(), baud_rate);
+	}
+
 	return props;
 }
 

--- a/ptz-visca.hpp
+++ b/ptz-visca.hpp
@@ -286,14 +286,16 @@ signals:
 	void reset();
 
 public:
-	ViscaUART(QString &port_name);
+	QSerialPort::BaudRate baud_rate = QSerialPort::Baud9600;
+
+	ViscaUART(QString &port_name, QSerialPort::BaudRate baud_rate= QSerialPort::Baud9600);
 	void open();
 	void close();
 	void send(const QByteArray &packet);
 	void receive_datagram(const QByteArray &packet);
 	QString portName() { return port_name; }
 
-	static ViscaUART *get_interface(QString port_name);
+	static ViscaUART *get_interface(QString port_name, QSerialPort::BaudRate baud_rate = QSerialPort::Baud9600);
 
 public slots:
 	void poll();


### PR DESCRIPTION
The baud rate of Visca Serial and Pelco-P can now be set. I restricted the baud rate options to some common values to keep everything clean.

Signed-off-by: Luuk Verhagen <developer@verhagenluuk.nl>