### PR TITLE
Fix compatibility of procedure ptz_pantilt

### DIFF
--- a/ptz-action-source.c
+++ b/ptz-action-source.c
@@ -61,17 +61,17 @@ static void ptz_action_source_do_action(struct ptz_action_source_data *context)
 	switch (context->action) {
 	case PTZ_ACTION_PRESET_RECALL:
 		calldata_set_int(&cd, "preset_id", context->preset_id);
-		proc_handler_call(obs_get_proc_handler(), "ptz_preset_recall", &cd);
+		proc_handler_call(ptz_get_proc_handler(), "ptz_preset_recall", &cd);
 		break;
 	case PTZ_ACTION_PAN_TILT:
 		calldata_set_float(&cd, "pan", context->pan_speed);
 		calldata_set_float(&cd, "tilt", context->tilt_speed);
-		proc_handler_call(obs_get_proc_handler(), "ptz_pantilt", &cd);
+		proc_handler_call(ptz_get_proc_handler(), "ptz_move_continuous", &cd);
 		break;
 	case PTZ_ACTION_STOP:
 		calldata_set_float(&cd, "pan", 0.0);
 		calldata_set_float(&cd, "tilt", 0.0);
-		proc_handler_call(obs_get_proc_handler(), "ptz_pantilt", &cd);
+		proc_handler_call(ptz_get_proc_handler(), "ptz_move_continuous", &cd);
 		break;
 	default:
 		break;

--- a/ptz-device.cpp
+++ b/ptz-device.cpp
@@ -399,7 +399,7 @@ void ptz_load_devices()
 	proc_handler_add(ph, "ptr ptz_get_proc_handler()", ptz_get_proc_handler, NULL);
 
 	/* Deprecated pantilt callback for compatibility with existing plugins */
-	proc_handler_add(ptz_ph, "void ptz_pantilt(int device_id, float pan, float tilt, float zoom, float focus)",
+	proc_handler_add(ph, "void ptz_pantilt(int device_id, float pan, float tilt, float zoom, float focus)",
 			ptz_move_continuous, NULL);
 }
 

--- a/ptz-device.cpp
+++ b/ptz-device.cpp
@@ -188,13 +188,25 @@ void PTZListModel::preset_recall(uint32_t device_id, int preset_id)
 		ptz->memory_recall(preset_id);
 }
 
-void PTZListModel::pantilt(uint32_t device_id, double pan, double tilt)
+enum {
+	MOVE_FLAG_PANTILT = 1 << 0,
+	MOVE_FLAG_ZOOM = 1 << 1,
+	MOVE_FLAG_FOCUS = 1 << 2,
+};
+
+void PTZListModel::move_continuous(uint32_t device_id, uint32_t flags, double pan, double tilt, double zoom, double focus)
 {
 	PTZDevice* ptz = ptzDeviceList.getDevice(device_id);
-	if (ptz)
-		ptz->pantilt(pan, tilt);
-}
+	if (!ptz)
+		return;
 
+	if (flags & MOVE_FLAG_PANTILT)
+		ptz->pantilt(pan, tilt);
+	if (flags & MOVE_FLAG_ZOOM)
+		ptz->zoom(zoom);
+	if (flags & MOVE_FLAG_FOCUS)
+		ptz->focus(focus);
+}
 
 PTZDevice::PTZDevice(OBSData config) : QObject()
 {
@@ -330,11 +342,18 @@ void ptz_devices_set_config(obs_data_array_t *devices)
 	}
 }
 
+static proc_handler_t *ptz_ph = NULL;
+
+proc_handler_t *ptz_get_proc_handler()
+{
+	return ptz_ph;
+}
+
 void ptz_load_devices()
 {
 	/* Register the proc handlers for issuing PTZ commands */
-	proc_handler_t *ph = obs_get_proc_handler();
-	if (!ph)
+	ptz_ph = proc_handler_create();
+	if (!ptz_ph)
 		return;
 
 	/* Preset Recall Callback */
@@ -343,16 +362,49 @@ void ptz_load_devices()
 					Q_ARG(uint32_t, calldata_int(cd, "device_id")),
 					Q_ARG(int, calldata_int(cd, "preset_id")));
 	};
-	proc_handler_add(ph, "void ptz_preset_recall(int device_id, int preset_id)",
+	proc_handler_add(ptz_ph, "void ptz_preset_recall(int device_id, int preset_id)",
 			ptz_preset_recall, NULL);
 
-	/* Pantilt Callback */
-	auto ptz_pantilt = [](void *data, calldata_t *cd) {
-		QMetaObject::invokeMethod(&ptzDeviceList, "pantilt",
-					Q_ARG(uint32_t, calldata_int(cd, "device_id")),
-					Q_ARG(double, calldata_float(cd, "pan")),
-					Q_ARG(double, calldata_float(cd, "tilt")));
+	auto ptz_move_continuous = [](void *data, calldata_t *cd) {
+		long long device_id;
+		double pan, tilt, zoom, focus;
+		if (!calldata_get_int(cd, "device_id", &device_id))
+			return;
+		int flags = 0;
+		if (calldata_get_float(cd, "pan", &pan) && calldata_get_float(cd, "tilt", &tilt))
+			flags |= MOVE_FLAG_PANTILT;
+		if (calldata_get_float(cd, "zoom", &zoom))
+			flags |= MOVE_FLAG_ZOOM;
+		if (calldata_get_float(cd, "focus", &focus))
+			flags |= MOVE_FLAG_FOCUS;
+		QMetaObject::invokeMethod(&ptzDeviceList, "move_continuous",
+						Q_ARG(uint32_t, device_id),
+						Q_ARG(uint32_t, flags),
+						Q_ARG(double, pan), Q_ARG(double, tilt),
+						Q_ARG(double, zoom),
+						Q_ARG(double, focus));
 	};
-	proc_handler_add(ph, "void ptz_pantilt(int device_id, float pan, float tilt)",
-			ptz_pantilt, NULL);
+	proc_handler_add(ptz_ph, "void ptz_move_continuous(int device_id, float pan, float tilt, float zoom, float focus)",
+			ptz_move_continuous, NULL);
+
+	/* Register the new proc hander with the main proc handler */
+	proc_handler_t *ph = obs_get_proc_handler();
+	if (!ph)
+		return;
+
+	/* Register a function for retrieving the PTZ call handler */
+	auto ptz_get_proc_handler = [](void *data, calldata_t *cd) {
+		calldata_set_ptr(cd, "return", ptz_ph);
+	};
+	proc_handler_add(ph, "ptr ptz_get_proc_handler()", ptz_get_proc_handler, NULL);
+
+	/* Deprecated pantilt callback for compatibility with existing plugins */
+	proc_handler_add(ptz_ph, "void ptz_pantilt(int device_id, float pan, float tilt, float zoom, float focus)",
+			ptz_move_continuous, NULL);
+}
+
+void ptz_unload_devices(void)
+{
+	proc_handler_destroy(ptz_ph);
+	ptz_ph = nullptr;
 }

--- a/ptz-device.hpp
+++ b/ptz-device.hpp
@@ -53,7 +53,7 @@ public:
 
 public slots:
 	void preset_recall(uint32_t device_id, int preset_id);
-	void pantilt(uint32_t device_id, double pan, double tilt);
+	void move_continuous(uint32_t device_id, uint32_t flags, double pan, double tilt, double zoom, double focus);
 };
 
 extern PTZListModel ptzDeviceList;

--- a/ptz.c
+++ b/ptz.c
@@ -26,7 +26,10 @@ bool obs_module_load()
 	return true;
 }
 
-void obs_module_unload() {}
+void obs_module_unload()
+{
+	ptz_unload_devices();
+}
 
 MODULE_EXPORT const char *obs_module_description(void)
 {

--- a/ptz.h
+++ b/ptz.h
@@ -21,6 +21,7 @@ extern "C" {
 #endif
 
 extern void ptz_load_devices(void);
+extern void ptz_unload_devices(void);
 extern void ptz_load_action_source(void);
 extern void ptz_load_controls(void);
 extern void ptz_load_settings(void);
@@ -29,6 +30,8 @@ extern obs_data_array_t *ptz_devices_get_config(void);
 extern void ptz_devices_set_config(obs_data_array_t *devices);
 
 extern bool ptz_scene_is_source_active(obs_source_t *scene, obs_source_t *source);
+
+extern proc_handler_t *ptz_get_proc_handler();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR fixes a compatibility issue that the [obs-face-tracker](https://github.com/norihiro/obs-face-tracker/) release 0.3.1-0.4.0 cannot send the new proc-handler of obs-ptz.
Since the old obs-face-tracker calls the procedure `ptz_pantilt` added to the global proc handler, the moved `ptz_pantilt` could not be called.

My proposal is one of them.
- If we need to keep compatibility, `ptz_pantilt` should not be moved. (this PR)
- If we just discard the compatibility, `ptz_pantilt` is not necessary and can be just removed.

Please feel free to squash with your commit 86c88580 when commit into your `main` branch.