### PR TITLE
Do not send relative-movement when releasing mouse

### DIFF
--- a/ptz-controls.cpp
+++ b/ptz-controls.cpp
@@ -397,12 +397,15 @@ void PTZControls::setPanTilt(double pan, double tilt)
 	if (!ptz)
 		return;
 
-	pantiltingFlag = std::abs(pan) > 0 || std::abs(tilt) > 0;
+	bool nonzero = std::abs(pan) > 0 || std::abs(tilt) > 0;
 	if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+		pantiltingFlag = nonzero;
 		ptz->pantilt(pan, tilt);
 	} else if (QGuiApplication::keyboardModifiers().testFlag(Qt::ShiftModifier)) {
-		ptz->pantilt_rel(pan, - tilt);
+		if (nonzero)
+			ptz->pantilt_rel(pan, - tilt);
 	} else {
+		pantiltingFlag = nonzero;
 		ptz->pantilt(pan * speed / 100, tilt * speed / 100);
 	}
 }


### PR DESCRIPTION
When clicking control buttons with shift key, two relative-movement commands are sent at pressing and releasing time. It be sent just at the pressing time.
This PR also change `pantiltingFlag` not to be set by shift+click since it is not necessary to stop later.
As a (good?) side effect of this change, a user can make camera keep moving by pushing mouse's left button, pushing a shift key, releasing the mouse, and then releasing the shift key.