### PR TITLE
Added basic support for IPC365 cameras

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Change obs-plugintemplate to your plugin's name in a machine-readable format
-# (e.g.: obs-myawesomeplugin) and set 
+# (e.g.: obs-myawesomeplugin) and set
 if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
 	execute_process(COMMAND git describe --always --tags --dirty=-modified
 		OUTPUT_VARIABLE PLUGIN_VERSION
@@ -84,6 +84,7 @@ set(PLUGIN_SOURCES
 	ptz-visca-uart.cpp
 	ptz-visca-udp.cpp
 	ptz-visca-tcp.cpp
+	ptz-ipc365.cpp
 	ptz-action-source.c
 	protocol-helpers.cpp
 	imported/qt-wrappers.cpp

--- a/ptz-controls.cpp
+++ b/ptz-controls.cpp
@@ -21,6 +21,7 @@
 #include "ptz-controls.hpp"
 #include "settings.hpp"
 #include "ptz-visca.hpp"
+#include "ptz-ipc365.hpp"
 #include "ptz-pelco.hpp"
 #include "ptz.h"
 

--- a/ptz-device.cpp
+++ b/ptz-device.cpp
@@ -11,6 +11,7 @@
 #include "ptz-visca-uart.hpp"
 #include "ptz-visca-udp.hpp"
 #include "ptz-visca-tcp.hpp"
+#include "ptz-ipc365.hpp"
 #include "ptz-pelco.hpp"
 #include "ptz.h"
 
@@ -173,6 +174,8 @@ PTZDevice *PTZListModel::make_device(OBSData config)
 		ptz = new PTZViscaOverIP(config);
 	if (type == "visca-over-tcp")
 		ptz = new PTZViscaOverTCP(config);
+	if (type == "ipc365")
+		ptz = new PTZIPC365(config);
 	return ptz;
 }
 

--- a/ptz-ipc365.cpp
+++ b/ptz-ipc365.cpp
@@ -1,0 +1,131 @@
+/* Pan Tilt Zoom IPC365 implementation
+ *
+ * Copyright 2022 Jonatã Bolzan Loss <jonata@jonata.org>
+ *
+ * SPDX-License-Identifier: GPLv2
+ */
+
+#include "imported/qt-wrappers.hpp"
+#include <QTimer>
+#include <QtEndian>
+#include "ptz-ipc365.hpp"
+
+PTZIPC365::PTZIPC365(OBSData config)
+	: PTZDevice(config)
+{
+	set_config(config);
+	auto_settings_filter += {"port", "host"};
+	tcp_socket.setSocketOption(QAbstractSocket::KeepAliveOption, 1);
+	connect(&tcp_socket, &QTcpSocket::stateChanged, this, &PTZIPC365::on_socket_stateChanged);
+}
+
+
+void PTZIPC365::pantilt(double pan_, double tilt_)
+{
+	if (!(pan_ == 0.0 && tilt_ == 0.0)) {
+		QByteArray cmd;
+
+		cmd.append(QByteArray::fromHex("ccddeeff774f0000e31269004800000000000000af93c63b09f74b01010000000000000000000000"));
+
+		if (pan_ < 0) {
+			int pan = 255 - ((pan_ * -1) * 10);
+			cmd.append(pan);
+			cmd.append(QByteArray::fromHex("ffffff"));
+		} else {
+			int pan = pan_ * 10;
+			cmd.append(pan);
+			cmd.append(QByteArray::fromHex("000000"));
+		}
+
+		if (tilt_ < 0) {
+			int tilt = 255 - ((tilt_ * -1) * 10);
+			cmd.append(tilt);
+			cmd.append(QByteArray::fromHex("ffffff"));
+		} else {
+			int tilt = tilt_ * 10;
+			cmd.append(tilt);
+			cmd.append(QByteArray::fromHex("000000"));
+		}
+
+		cmd.append(QByteArray::fromHex("0000000000000000000000000000000000000000000000"));
+
+		send(cmd);
+	};
+}
+
+void PTZIPC365::pantilt_home()
+{
+	pantilt_abs(255, 255);
+}
+
+void PTZIPC365::pantilt_abs(int pan, int tilt)
+{
+	QByteArray cmd;
+	cmd.append(QByteArray::fromHex("ccddeeff774f0000e31269004800000000000000af93c63b09f74b01010000000000000000000000"));
+	cmd.append(pan);
+	cmd.append(QByteArray::fromHex("000000"));
+	cmd.append(tilt);
+	cmd.append(QByteArray::fromHex("000000"));
+	cmd.append(QByteArray::fromHex("0000000000000000000000000000000000000000000000"));
+	send(cmd);
+}
+
+void PTZIPC365::connectSocket()
+{
+	tcp_socket.connectToHost(host, port);
+}
+
+void PTZIPC365::on_socket_stateChanged(QAbstractSocket::SocketState state)
+{
+	blog(LOG_INFO, "IPC365 socket state: %s", qPrintable(QVariant::fromValue(state).toString()));
+	switch (state) {
+	case QAbstractSocket::UnconnectedState:
+		/* Attempt reconnection periodically */
+		QTimer::singleShot(900, this, SLOT(connectSocket));
+		break;
+	case QAbstractSocket::ConnectedState:
+		blog(LOG_INFO, "IPC365 %s connected", QT_TO_UTF8(objectName()));
+		// reset();s
+		break;
+	default:
+		break;
+	}
+}
+
+void PTZIPC365::send(const QByteArray &msg)
+{
+	if (tcp_socket.state() == QAbstractSocket::UnconnectedState)
+		connectSocket();
+	ptz_debug("IPC365 --> %s", qPrintable(msg.toHex()));
+	tcp_socket.write(msg);
+}
+
+
+void PTZIPC365::set_config(OBSData config)
+{
+	PTZDevice::set_config(config);
+	host = obs_data_get_string(config, "host");
+	port = obs_data_get_int(config, "port");
+	if (!port)
+		port = 23456;
+	connectSocket();
+}
+
+OBSData PTZIPC365::get_config()
+{
+	OBSData config = PTZDevice::get_config();
+	obs_data_set_string(config, "host", QT_TO_UTF8(host));
+	obs_data_set_int(config, "port", port);
+	return config;
+}
+
+obs_properties_t *PTZIPC365::get_obs_properties()
+{
+	obs_properties_t *props = PTZDevice::get_obs_properties();
+	obs_property_t *p = obs_properties_get(props, "interface");
+	obs_properties_t *config = obs_property_group_content(p);
+	obs_property_set_description(p, "IPC365 Connection");
+	obs_properties_add_text(config, "host", "IP Host", OBS_TEXT_DEFAULT);
+	obs_properties_add_int(config, "port", "TCP port", 1, 65535, 1);
+	return props;
+}

--- a/ptz-ipc365.hpp
+++ b/ptz-ipc365.hpp
@@ -1,0 +1,40 @@
+/* Pan Tilt Zoom IPC365 implementation
+ *
+ * Copyright 2022 Jonatã Bolzan Loss <jonata@jonata.org>
+ *
+ * SPDX-License-Identifier: GPLv2
+ */
+#pragma once
+
+#include <QObject>
+#include <QTcpSocket>
+#include "ptz-device.hpp"
+
+class PTZIPC365 : public PTZDevice {
+	Q_OBJECT
+
+private:
+	QTcpSocket tcp_socket;
+	QByteArray rxbuffer;
+	QString host;
+	int port;
+
+protected:
+	void send(const QByteArray &msg);
+
+private slots:
+	void connectSocket();
+	void on_socket_stateChanged(QAbstractSocket::SocketState);
+
+public:
+	PTZIPC365(OBSData config);
+
+	void set_config(OBSData ptz_data);
+	OBSData get_config();
+
+    obs_properties_t *get_obs_properties();
+
+    void pantilt(double pan, double tilt);
+	void pantilt_abs(int pan, int tilt);
+    void pantilt_home();
+};

--- a/settings.cpp
+++ b/settings.cpp
@@ -169,6 +169,7 @@ void PTZSettings::on_addPTZ_clicked()
 	QAction *addViscaSerial = addPTZContext.addAction("VISCA Serial");
 	QAction *addViscaUDP = addPTZContext.addAction("VISCA over UDP");
 	QAction *addViscaTCP = addPTZContext.addAction("VISCA over TCP");
+	QAction *addIPC365 = addPTZContext.addAction("IPC365");
 	QAction *addPelcoD = addPTZContext.addAction("Pelco D");
 	QAction *addPelcoP = addPTZContext.addAction("Pelco P");
 	QAction *action = addPTZContext.exec(QCursor::pos());
@@ -191,6 +192,13 @@ void PTZSettings::on_addPTZ_clicked()
 		obs_data_release(cfg);
 		obs_data_set_string(cfg, "type", "visca-over-tcp");
 		obs_data_set_int(cfg, "port", 5678);
+		ptzDeviceList.make_device(cfg);
+	}
+	if (action == addIPC365) {
+		OBSData cfg = obs_data_create();
+		obs_data_release(cfg);
+		obs_data_set_string(cfg, "type", "ipc365");
+		obs_data_set_int(cfg, "port", 23456);
 		ptzDeviceList.make_device(cfg);
 	}
 	if (action == addPelcoD) {


### PR DESCRIPTION
This adds support for pan and tilt on IPC365 cameras. It's a generic Chinese camera, known to be used with the IPC 360 app. It seems it doesn't have real "Onvif" support for PTZ commands. Thanks for considering!