### PR TITLE
ptz-visca: Fix memory leak

### DIFF
--- a/ptz-visca.cpp
+++ b/ptz-visca.cpp
@@ -468,12 +468,14 @@ void PTZVisca::set_settings(OBSData new_settings)
 	/* `updates` is the property values that should be cached */
 	OBSData updates = obs_data_create();
 	obs_data_release(updates);
+	bool changed = false;
 
 	if (obs_data_has_user_value(new_settings, "power_on")) {
 		bool power_on = obs_data_get_bool(new_settings, "power_on");
 		if (power_on != obs_data_get_bool(settings, "power_on")) {
 			send(VISCA_CAM_Power, {power_on});
 			obs_data_set_bool(updates, "power_on", power_on);
+			changed = true;
 		}
 	}
 
@@ -481,6 +483,7 @@ void PTZVisca::set_settings(OBSData new_settings)
 	if (wb_mode != obs_data_get_int(settings, "wb_mode")) {
 		send(VISCA_CAM_WB_Mode, {wb_mode});
 		obs_data_set_int(updates, "wb_mode", wb_mode);
+		changed = true;
 	}
 
 	if (obs_data_has_user_value(new_settings, "wb_onepush_trigger")) {
@@ -488,7 +491,7 @@ void PTZVisca::set_settings(OBSData new_settings)
 		send(VISCA_CAM_WB_OnePushTrigger);
 	}
 
-	if (obs_data_first(updates) != nullptr) {
+	if (changed) {
 		obs_data_apply(settings, updates);
 		emit settingsChanged(updates);
 	}


### PR DESCRIPTION
### Description

The API `obs_data_first` requires to release the returned object. Instead of `obs_data_first`, prepare a bool variable named `changed` to judge the settings was changed.

### Motivation and Context

This PR fixes a memory leak when clicking `Power On` and `Power Off` on the menu for a VISCA device.

### How Has This Been Tested?
- Start OBS
- Add PTZ camera (SRG-120DH)
- Right click the PTZ camera
- Click `Power On`
- Exit OBS
- Check there is no memory leak.