### PR TITLE
fix ptz action on blocked ptz

### DIFF
--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -554,6 +554,10 @@ void PTZControls::updateMoveControls()
 		}
 	}
 
+	if(ptz) ptz->setPtzCtrlsEnabled(ctrls_enabled);
+	//blog(LOG_INFO, "updateMoveControls() active:%s",
+	//				ctrls_enabled ? "true" : "false");
+
 	ui->actionDisableLiveMoves->setVisible(
 		obs_frontend_preview_program_mode_active() &&
 		live_moves_disabled);

--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -197,8 +197,12 @@ void PTZListModel::delete_all()
 void PTZListModel::preset_recall(uint32_t device_id, int preset_id)
 {
 	PTZDevice *ptz = ptzDeviceList.getDevice(device_id);
-	if (ptz)
+
+	if (ptz && ptz->ptz_ctrls_enabled) {
+		//blog(LOG_INFO, "preset_recall() active:%s preset_id %d",
+		//			ptz->ptz_ctrls_enabled ? "true" : "false", preset_id);
 		ptz->memory_recall(preset_id);
+	}
 }
 
 enum {
@@ -232,6 +236,7 @@ PTZDevice::PTZDevice(OBSData config) : QObject()
 	obs_data_release(settings);
 	ptzDeviceList.add(this);
 	preset_names_model.setStringList(default_preset_names);
+	ptz_ctrls_enabled = true;
 };
 
 PTZDevice::~PTZDevice()

--- a/src/ptz-device.hpp
+++ b/src/ptz-device.hpp
@@ -81,6 +81,8 @@ protected:
 	obs_properties_t *props;
 	OBSData settings;
 
+	bool ptz_ctrls_enabled;
+
 signals:
 	void settingsChanged(OBSData settings);
 
@@ -88,6 +90,8 @@ public:
 	~PTZDevice();
 	PTZDevice(OBSData config);
 	uint32_t getId() { return id; }
+
+	void setPtzCtrlsEnabled(bool enabled) { ptz_ctrls_enabled = enabled; };
 
 	void setObjectName(QString name);
 


### PR DESCRIPTION
Hi! My ptzs where moving according to the "ptz action" defined when "preview" and "program" where on the same camera.
I have extended the concept to block any kind of ptz move, including "ptz action", if the block is active.
I've made the simplest change that could work. What do you think?