### PR TITLE
onvif: Convert generator code to QXmlStreamWriter

### DIFF
--- a/src/ptz-onvif.hpp
+++ b/src/ptz-onvif.hpp
@@ -11,6 +11,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QtXml/QDomDocument>
+#include <QXmlStreamWriter>
 #include <QObject>
 #include <QUuid>
 #include <QAuthenticator>
@@ -23,18 +24,6 @@ class MediaProfile {
 public:
 	QString name;
 	QString token;
-};
-
-class SoapRequest : QObject {
-	Q_OBJECT
-public:
-	QString username, password, host;
-	QString body, action;
-	QList<QString> XMLNs;
-	QString createRequest();
-
-private:
-	QString createUserToken();
 };
 
 class PTZOnvif : public PTZDevice {
@@ -53,20 +42,25 @@ private:
 	QString m_PTZAddress{""};
 	MediaProfile m_selectedMedia;
 
-	void sendRequest(SoapRequest *soap_req);
-	void handleResponse(QString response);
+	// SOAP/XML helpers
+	void writeHeader(QXmlStreamWriter &s, const QString action);
+
+	void sendRequest(QString host, QString req);
 	void getCapabilities();
-	void handleGetCapabilitiesResponse(QDomNode node);
 	void getProfiles();
+	void getPresets();
+	void handleResponse(QString response);
+	void handleGetPresetsResponse(QDomDocument &doc);
+	void handleGetCapabilitiesResponse(QDomNode node);
 	void handleGetProfilesResponse(QDomNode node);
-	SoapRequest *createSoapRequest();
+
+	void genericMove(QString movetype, QString property, double pan,
+			 double tilt, double zoom);
 	void continuousMove(double x, double y, double z);
 	void absoluteMove(int x, int y, int z);
 	void relativeMove(int x, int y, int z);
 	void stop();
 	void goToHomePosition();
-	void getPresets();
-	void handleGetPresetsResponse(QDomDocument doc);
 
 private slots:
 	void connectCamera();


### PR DESCRIPTION
Instead of hand coding the XML, use QXmlStreamWriter which guarantees the XML is correctly formed and make the code easier to read. This should be a no-op change from the hand coded XML.

@jonata Can you please review these changes? I've refactored the code to use XML namespaces correctly and to use QXmlStreamWriter. It works on my end, but I'd like to have another set of eyeballs look over the changes.