### PR TITLE
Move the addition of command affects to stale settings from send_pend…

### DIFF
--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -195,6 +195,7 @@ Usage: %B${functrace[1]%:*}%b <option> [<options>]
     if (( _loglevel > 2 )) cmake_args+=(--debug-output)
 
     local num_procs
+    local cmake_filter=cat
 
     case ${target} {
       macos-*)
@@ -202,7 +203,10 @@ Usage: %B${functrace[1]%:*}%b <option> [<options>]
         if (( ${+CODESIGN} )) {
           read_codesign
         }
-
+        if [[ ${generator} == 'Xcode' ]] && (( ${+commands[xcbeautify]} )) {
+          cmake_filter=(xcbeautify)
+          if (( _loglevel > 1 )) cmake_filter+=(--preserve-unbeautified)
+        }
         cmake_args+=(
           -DCMAKE_FRAMEWORK_PATH="${_plugin_deps}/Frameworks"
           -DCMAKE_OSX_ARCHITECTURES=${${target##*-}//universal/x86_64;arm64}
@@ -227,7 +231,7 @@ Usage: %B${functrace[1]%:*}%b <option> [<options>]
     local -a cmake_args=()
     if (( _loglevel > 1 )) cmake_args+=(--verbose)
     if [[ ${generator} == 'Unix Makefiles' ]] cmake_args+=(--parallel ${num_procs})
-    cmake --build build_${target##*-} --config ${BUILD_CONFIG:-RelWithDebInfo} ${cmake_args}
+    cmake --build build_${target##*-} --config ${BUILD_CONFIG:-RelWithDebInfo} ${cmake_args} | ${cmake_filter}
   }
 
   log_info "Installing ${product_name}..."

--- a/.github/scripts/Build-Windows.ps1
+++ b/.github/scripts/Build-Windows.ps1
@@ -47,7 +47,7 @@ function Build {
     $ProductVersion = (git -C ${ProjectRoot} describe --tags --dirty)
 
     $script:DepsVersion = ''
-    $script:QtVersion = '5'
+    $script:QtVersion = '6'
     $script:VisualStudioVersion = ''
     $script:PlatformSDK = '10.0.18363.657'
 
@@ -71,7 +71,7 @@ function Build {
             "-DCMAKE_SYSTEM_VERSION=${script:PlatformSDK}"
             "-DCMAKE_GENERATOR_PLATFORM=$(if (${script:Target} -eq "x86") { "Win32" } else { "x64" })"
             "-DCMAKE_BUILD_TYPE=${Configuration}"
-            "-DCMAKE_PREFIX_PATH:PATH=$(Resolve-Path -Path "${ProjectRoot}/../obs-build-dependencies/${DepsPath}")"
+            "-DCMAKE_PREFIX_PATH:PATH=$(Resolve-Path -Path "${ProjectRoot}/../obs-build-dependencies/${DepsPath}/lib/cmake")"
             "-DQT_VERSION=${script:QtVersion}"
         )
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 
 #cmake
+/cmakefiles/
 /cmbuild/
 /build/
 /build32/
@@ -16,11 +17,13 @@
 /debug32/
 /debug64/
 /builds/
+build_*
 .vs/
 *.o.d
 *.ninja
 .ninja*
 .dirstamp
+cmakecache.txt
 
 #xcode
 *.xcodeproj/

--- a/buildspec.json
+++ b/buildspec.json
@@ -1,10 +1,18 @@
 {
     "dependencies": {
         "obs-studio": {
-            "version": "28.0.1",
+            "version": "30.2.3",
             "repository": "https://github.com/obsproject/obs-studio.git",
-            "branch": "master",
-            "hash": "e8dc70d0eef4503378d6ac300e680215eb5c9379"
+            "branch": "release/30.2",
+            "hash": "ca51d330eafd36f84f159e524aa87d11ac39197f"
+        },
+				"obs-studio-not-working": {
+            "version": "30.2.3",
+            "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
+            "label": "OBS sources",
+            "hashes": {
+                "windows-x64": "c2dd03fa7fd01fad5beafce8f7156da11f9ed9a588373fd40b44a06f4c03b867"
+            }
         },
 	"sdl": {
 	    "version": "release-2.26.3",
@@ -13,14 +21,14 @@
 	    "hash": "adf31f6ec0be0f9ba562889398f71172c7941023"
 	},
         "prebuilt": {
-            "version": "2022-08-02",
+            "version": "2024-03-19",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-built obs-deps",
             "hashes": {
                 "macos-x86_64": "7637e52305e6fc53014b5aabd583f1a4490b1d97450420e977cae9a336a29525",
                 "macos-arm64": "755e0fa69b17a3ae444e1befa9d91d77e3cafe628fbd1c6333686091826595cd",
                 "macos-universal": "de057e73e6fe0825664c258ca2dd6798c41ae580bf4d896e1647676a4941934a",
-                "windows-x64": "2192d8ce780c4281b807cd457994963669e5202659ecd92f19b54c3e7d0c1915",
+                "windows-x64": "6e86068371526a967e805f6f9903f9407adb683c21820db5f07da8f30d11e998",
                 "windows-x86": "9f8582ab5891b000869d6484ea591add9fbac9f1c91b56c7b85fdfd56a261c1b"
             }
         },
@@ -41,17 +49,11 @@
             }
         },
         "qt6": {
-            "version": "2022-08-02",
-            "baseUrl": "https://github.com/glikely/obs-deps-qtserialport/releases/download",
+            "version": "2024-10-05",
+            "baseUrl": "https://github.com/gentoogeek/obs-deps/releases/download",
             "label": "Pre-built Qt6",
             "hashes": {
-                "macos-x86_64": "7470596958bcf28811b084897f01477e1e20b027755c4d04e363247e8f45cfd8",
-                "macos-arm64": "894323c30fca6da0958c903ebdbb687139e96cc079a68e54162b0e7a475e31a7",
-                "macos-universal": "437660339210b52309ab6997771a23511dd2ce3474b55e137490640b6bb24c59",
-                "windows-x64": "5e8bb9679547d7caeb68010ef4ee94b409f5900298f9306ab4678cd60ea22647"
-            },
-            "pdb-hashes": {
-                "windows-x64": "512ad05c70e1ac2a43cab73b90390bc8ade7b5a364acb280ee4c50e8ef9ef95b"
+                "windows-x64": "8AEE1F11F8E16EE3EBD4C5BF7E2BAF73414A34AB7CBA2E64B7DC6539226C09F9"
             }
         }
     },

--- a/scripts/run-windows.ps1
+++ b/scripts/run-windows.ps1
@@ -1,5 +1,5 @@
 Push-Location $PSScriptRoot\..
-cp -r -force .\release\* ..\obs-studio\build64\rundir\RelWithDebInfo\
-cd ..\obs-studio\build64\rundir\RelWithDebInfo\bin\64bit
+cp -r -force .\release\* ..\obs-studio\build_x64\rundir\RelWithDebInfo\
+cd ..\obs-studio\build_x64\rundir\RelWithDebInfo\bin\64bit
 .\obs64.exe
 Pop-Location

--- a/src/imported/qjoysticks/SDL_Joysticks.cpp
+++ b/src/imported/qjoysticks/SDL_Joysticks.cpp
@@ -106,7 +106,7 @@ QMap<int, QJoystickDevice *> SDL_Joysticks::joysticks()
 
 	return joysticks;
 #endif
-	return QMap<int, QJoystickDevice *>();
+	//return QMap<int, QJoystickDevice *>();
 }
 
 /**

--- a/src/ptz-action-source.c
+++ b/src/ptz-action-source.c
@@ -83,6 +83,12 @@ static void ptz_action_source_do_action(struct ptz_action_source_data *context)
 		proc_handler_call(ptz_get_proc_handler(), "ptz_move_continuous",
 				  &cd);
 		break;
+	case PTZ_ACTION_POWER_ON:
+		proc_handler_call(ptz_get_proc_handler(), "ptz_power_on", &cd);
+		break;
+	case PTZ_ACTION_POWER_OFF:
+		proc_handler_call(ptz_get_proc_handler(), "ptz_power_off", &cd);
+		break;
 	default:
 		break;
 	}
@@ -292,6 +298,8 @@ static obs_properties_t *ptz_action_source_get_properties(void *data)
 	obs_property_list_add_int(prop, "Preset Save", PTZ_ACTION_PRESET_SAVE);
 	obs_property_list_add_int(prop, "Pan/Tilt", PTZ_ACTION_PAN_TILT);
 	obs_property_list_add_int(prop, "Stop", PTZ_ACTION_STOP);
+	obs_property_list_add_int(prop, "Power On", PTZ_ACTION_POWER_ON);
+	obs_property_list_add_int(prop, "Power Off", PTZ_ACTION_POWER_OFF);
 
 	obs_properties_add_list(props, "preset_id", "Preset",
 				OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);

--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -923,7 +923,6 @@ void PTZControls::on_cameraList_customContextMenuRequested(const QPoint &pos)
 	QAction *action = context.exec(globalpos);
 
 	OBSData setdata = obs_data_create();
-	obs_data_release(setdata);
 
 	if (action == powerAction) {
 		obs_data_set_bool(setdata, "power_on", !power_on);
@@ -932,6 +931,8 @@ void PTZControls::on_cameraList_customContextMenuRequested(const QPoint &pos)
 		obs_data_set_bool(setdata, "wb_onepush_trigger", true);
 		ptz->set_settings(setdata);
 	}
+	
+	obs_data_release(setdata);
 }
 
 void PTZControls::on_actionPTZProperties_triggered()

--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -291,6 +291,25 @@ void PTZListModel::move_continuous(uint32_t device_id, uint32_t flags,
 		ptz->focus(focus);
 }
 
+
+void PTZListModel::power_on(uint32_t device_id)
+{
+	PTZDevice *ptz = ptzDeviceList.getDevice(device_id);
+	if (!ptz)
+		return;
+
+	ptz->power(true);
+}
+
+void PTZListModel::power_off(uint32_t device_id)
+{
+	PTZDevice *ptz = ptzDeviceList.getDevice(device_id);
+	if (!ptz)
+		return;
+
+	ptz->power(false);
+}
+
 int PTZPresetListModel::rowCount(const QModelIndex &parent) const
 {
 	Q_UNUSED(parent);
@@ -709,6 +728,42 @@ void ptz_load_devices()
 		ptz_ph,
 		"void ptz_move_continuous(int device_id, float pan, float tilt, float zoom, float focus)",
 		ptz_move_continuous, NULL);
+
+	auto ptz_power_on = [](void *data, calldata_t *cd){
+		Q_UNUSED(data);
+		long long device_id;
+		if (!calldata_get_int(cd, "device_id", &device_id))
+			return;
+	
+		
+		 QMetaObject::invokeMethod(
+			&ptzDeviceList, "power_on",
+			Q_ARG(uint32_t, device_id));
+		
+	};
+
+	proc_handler_add(
+		ptz_ph,
+		"void ptz_power_on(int device_id)",
+		ptz_power_on, NULL);
+		
+	auto ptz_power_off = [](void *data, calldata_t *cd){
+		Q_UNUSED(data);
+		long long device_id;
+		if (!calldata_get_int(cd, "device_id", &device_id))
+			return;
+		
+		QMetaObject::invokeMethod(
+			&ptzDeviceList, "power_off",
+			Q_ARG(uint32_t, device_id));
+		
+	};
+
+	proc_handler_add(
+		ptz_ph,
+		"void ptz_power_off(int device_id)",
+		ptz_power_off, NULL);
+
 
 	/* Register the new proc hander with the main proc handler */
 	proc_handler_t *ph = obs_get_proc_handler();

--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -484,6 +484,38 @@ QString PTZDevice::description()
 	return QString::fromStdString(type);
 }
 
+void PTZDevice::pantilt(double pan, double tilt)
+{
+	pan = std::clamp(pan, -pantilt_speed_max, pantilt_speed_max);
+	tilt = std::clamp(tilt, -pantilt_speed_max, pantilt_speed_max);
+	if ((pan_speed == pan) && (tilt_speed == tilt))
+		return;
+	pan_speed = pan;
+	tilt_speed = tilt;
+	status |= STATUS_PANTILT_SPEED_CHANGED;
+	do_update();
+}
+
+void PTZDevice::zoom(double speed)
+{
+	speed = std::clamp(speed, -zoom_speed_max, zoom_speed_max);
+	if (zoom_speed == speed)
+		return;
+	zoom_speed = speed;
+	status |= STATUS_ZOOM_SPEED_CHANGED;
+	do_update();
+}
+
+void PTZDevice::focus(double speed)
+{
+	speed = std::clamp(speed, -focus_speed_max, focus_speed_max);
+	if (focus_speed == speed)
+		return;
+	focus_speed = speed;
+	status |= STATUS_FOCUS_SPEED_CHANGED;
+	do_update();
+}
+
 void PTZDevice::set_config(OBSData config)
 {
 	/* Update the list of preset names */

--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -740,6 +740,21 @@ void ptz_load_devices()
 			&ptzDeviceList, "power_on",
 			Q_ARG(uint32_t, device_id));
 		
+		
+		/*
+		BSData setdata = obs_data_create();		
+		
+		PTZDevice *ptz = ptzDeviceList.getDevice(device_id);
+		obs_data_set_bool(setdata, "power_on", true);
+		ptz->set_settings(setdata);
+		
+		obs_data_release(setdata);
+		*/
+		/*
+		PTZDevice *ptz = ptzDeviceList.getDevice(device_id);
+		ptz->power(true);
+		*/
+		
 	};
 
 	proc_handler_add(
@@ -757,6 +772,20 @@ void ptz_load_devices()
 			&ptzDeviceList, "power_off",
 			Q_ARG(uint32_t, device_id));
 		
+		
+		/*
+		OBSData setdata = obs_data_create();		
+		
+		PTZDevice *ptz = ptzDeviceList.getDevice(device_id);
+		obs_data_set_bool(setdata, "power_on", false);
+		ptz->set_settings(setdata);
+		
+		obs_data_release(setdata);
+		*/
+		/*
+		PTZDevice *ptz = ptzDeviceList.getDevice(device_id);
+		ptz->power(false);
+		*/
 	};
 
 	proc_handler_add(

--- a/src/ptz-device.hpp
+++ b/src/ptz-device.hpp
@@ -179,17 +179,7 @@ public:
 	 * zoom: range[0.0, 1.0], 0.0 == wide angle, 1.0 == telephoto
 	 * focus: range[0.0, 1.0], 0.0 == far focus, 1.0 == near focus
 	 */
-	void pantilt(double pan, double tilt)
-	{
-		pan = std::clamp(pan, -pantilt_speed_max, pantilt_speed_max);
-		tilt = std::clamp(tilt, -pantilt_speed_max, pantilt_speed_max);
-		if ((pan_speed == pan) && (tilt_speed == tilt))
-			return;
-		pan_speed = pan;
-		tilt_speed = tilt;
-		status |= STATUS_PANTILT_SPEED_CHANGED;
-		do_update();
-	}
+	void pantilt(double pan, double tilt);
 	virtual void pantilt_rel(double pan, double tilt)
 	{
 		Q_UNUSED(pan);
@@ -201,26 +191,10 @@ public:
 		Q_UNUSED(tilt);
 	}
 	virtual void pantilt_home() {}
-	void zoom(double speed)
-	{
-		speed = std::clamp(speed, -zoom_speed_max, zoom_speed_max);
-		if (zoom_speed == speed)
-			return;
-		zoom_speed = speed;
-		status |= STATUS_ZOOM_SPEED_CHANGED;
-		do_update();
-	}
+	void zoom(double speed);
 	virtual void zoom_abs(double pos) { Q_UNUSED(pos); };
 	virtual void set_autofocus(bool enabled) { Q_UNUSED(enabled); };
-	void focus(double speed)
-	{
-		speed = std::clamp(speed, -focus_speed_max, focus_speed_max);
-		if (focus_speed == speed)
-			return;
-		focus_speed = speed;
-		status |= STATUS_FOCUS_SPEED_CHANGED;
-		do_update();
-	}
+	void focus(double speed);
 	virtual void focus_abs(double pos) { Q_UNUSED(pos); }
 	virtual void focus_onetouch() {}
 	virtual void memory_set(int i) { Q_UNUSED(i); }

--- a/src/ptz-device.hpp
+++ b/src/ptz-device.hpp
@@ -60,6 +60,8 @@ public slots:
 	void preset_save(uint32_t device_id, int preset_id);
 	void move_continuous(uint32_t device_id, uint32_t flags, double pan,
 			     double tilt, double zoom, double focus);
+	void power_on(uint32_t device_id);
+	void power_off(uint32_t device_id);
 };
 
 extern PTZListModel ptzDeviceList;
@@ -200,6 +202,7 @@ public:
 	virtual void memory_set(int i) { Q_UNUSED(i); }
 	virtual void memory_recall(int i) { Q_UNUSED(i); }
 	virtual void memory_reset(int i) { Q_UNUSED(i); }
+	virtual void power(bool on) { Q_UNUSED(on); }
 	virtual QAbstractListModel *presetModel() { return &m_presetsModel; }
 
 	/* `config` is the device configuration, saved to the config file

--- a/src/ptz-visca.cpp
+++ b/src/ptz-visca.cpp
@@ -974,3 +974,8 @@ void PTZVisca::memory_recall(int i)
 {
 	send(VISCA_CAM_Memory_Recall, {i});
 }
+
+void PTZVisca::power(bool on)
+{
+	send(VISCA_CAM_Power, {(int)on});
+}

--- a/src/ptz-visca.cpp
+++ b/src/ptz-visca.cpp
@@ -661,9 +661,11 @@ void PTZVisca::set_settings(OBSData new_settings)
 			send(VISCA_CAM_Power, {power_on});
 	}
 
-	auto wb_mode = (int)obs_data_get_int(new_settings, "wb_mode");
-	if (wb_mode != obs_data_get_int(settings, "wb_mode")) {
-		send(VISCA_CAM_WB_Mode, {wb_mode});
+	if (obs_data_has_user_value(new_settings, "wb_mode")) {
+		auto wb_mode = (int)obs_data_get_int(new_settings, "wb_mode");
+		if (wb_mode != obs_data_get_int(settings, "wb_mode")) {
+			send(VISCA_CAM_WB_Mode, {wb_mode});
+		}
 	}
 
 	if (obs_data_has_user_value(new_settings, "wb_onepush_trigger")) {

--- a/src/ptz-visca.cpp
+++ b/src/ptz-visca.cpp
@@ -878,6 +878,12 @@ void PTZVisca::send_pending()
 						visca_focus_speed_max + 1)});
 			pending_cmds += cmd;
 		} else if (status & STATUS_CONNECTED) {
+			if (pan_speed || tilt_speed)
+				stale_settings += "pan_pos";
+			if (zoom_speed)
+				stale_settings += "zoom_pos";
+			if (focus_speed)
+				stale_settings += "focus_pos";
 			ptz_debug(
 				"Stale prop list: {%s}",
 				QT_TO_UTF8(stale_settings.values().join(',')));

--- a/src/ptz-visca.hpp
+++ b/src/ptz-visca.hpp
@@ -74,4 +74,5 @@ public:
 	void memory_reset(int i);
 	void memory_set(int i);
 	void memory_recall(int i);
+	void power(bool on);
 };


### PR DESCRIPTION
…ing to receive

As mentioned in issue #170, adding a command's affects to stale_settings as the command is being sent causes the VISCA controller to generate an inquiry for the stale setting before the camera has had a chance to change the setting.  This was discovered particularly for Power On/Off setting.

By moving the code to the receive function after the camera sends a completion message for the command, we are assured that the result of the inquiry to refresh the stale setting will be the current setting.

Reported By: GeNTooGeek
Signed-off-by: GeNTooGeek <gentoogeek@3g5g.ca>