### PR TITLE
Add option to disable sending udp sequence data

### DIFF
--- a/src/ptz-visca-udp.hpp
+++ b/src/ptz-visca-udp.hpp
@@ -16,9 +16,9 @@ class ViscaUDPSocket : public QObject {
 private:
 	/* Global lookup table of UART instances, used to eliminate duplicates */
 	static std::map<int, ViscaUDPSocket *> interfaces;
-
 	int visca_port;
 	QUdpSocket visca_socket;
+	
 
 signals:
 	void receive(const QByteArray &packet);
@@ -29,6 +29,7 @@ public:
 	void receive_datagram(QNetworkDatagram &datagram);
 	void send(QHostAddress ip_address, const QByteArray &packet);
 	int port() { return visca_port; }
+	bool disable_sequence;
 
 	static ViscaUDPSocket *get_interface(int port);
 
@@ -40,6 +41,7 @@ class PTZViscaOverIP : public PTZVisca {
 	Q_OBJECT
 
 private:
+
 	int sequence;
 	QHostAddress ip_address;
 	ViscaUDPSocket *iface;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -258,6 +258,7 @@ void PTZSettings::on_addPTZ_clicked()
 		obs_data_release(cfg);
 		obs_data_set_string(cfg, "type", "visca-over-ip");
 		obs_data_set_int(cfg, "port", 52381);
+		obs_data_set_bool(cfg, "disable_sequence", false);
 		ptzDeviceList.make_device(cfg);
 	}
 	if (action == addViscaTCP) {


### PR DESCRIPTION
#177 
Some cameras and devices do not work correctly with the visca sequence data via UDP.
This update adds an option "Disable sequence" to VISCA/UDP connections, to workaround this issue.
