### PR TITLE
Quirk: Support VISCA UDP without sequence field

### DIFF
--- a/src/ptz-visca-udp.hpp
+++ b/src/ptz-visca-udp.hpp
@@ -29,6 +29,7 @@ public:
 	void receive_datagram(QNetworkDatagram &datagram);
 	void send(QHostAddress ip_address, const QByteArray &packet);
 	int port() { return visca_port; }
+	bool quirk_visca_udp_no_seq;
 
 	static ViscaUDPSocket *get_interface(int port);
 


### PR DESCRIPTION
Some cameras don't use the UDP sequence number field in their VISCA UDP protocol. Support them by adding a quirk flag to modify the behaviour.

Fixes #177
Closes #178
Signed-off-by: Grant Likely <grant.likely@secretlab.ca>