### PR TITLE
Windows: create an installer

### DIFF
--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -67,6 +67,21 @@ function Package {
     }
     Compress-Archive -Force @CompressArgs
     Log-Group
+
+    Log-Group "Creating ${ProductName} Installer..."
+    $Iscc = "C:\Program Files (x86)\Inno Setup 6\iscc.exe"
+    $IsccFile = "${ProjectRoot}/build_${Target}/installer-Windows.iss"
+    # Throw an error if the provided path is invalid
+    if ( ! ( Test-Path -Path $IsccFile ) ) {
+        throw 'InnoSetup install script ${IsccFile} not found. Run the build script or the CMake build and install procedures first.'
+    }
+    Push-Location -Stack BuildTemp
+    Ensure-Location -Path "${ProjectRoot}/release"
+    Copy-Item -Path ${Configuration}/${ProductName} -Destination Package -Recurse
+    Invoke-External ${Iscc} ${IsccFile} /O"${ProjectRoot}/release" /F"${OutputName}-Installer"
+    Remove-Item -Path Package -Recurse
+    Pop-Location -Stack BuildTemp
+    Log-Group
 }
 
 Package

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 !CMakePresets.json
 !LICENSE
 !README.md
+!installer-Windows.iss.in
 !*.md
 
 # Exclude lock files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,3 +116,7 @@ if(ENABLE_JOYSTICK)
 endif()
 
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})
+
+if (OS_WINDOWS)
+  configure_file(installer-Windows.iss.in ${CMAKE_BINARY_DIR}/installer-Windows.iss)
+endif()

--- a/installer-Windows.iss.in
+++ b/installer-Windows.iss.in
@@ -1,0 +1,46 @@
+#define MyAppName "@CMAKE_PROJECT_NAME@"
+#define MyAppFullName "PTZ Controls (for OBS Studio)"
+#define MyAppVersion "@PLUGIN_VERSION@"
+#define MyAppPublisher "@PLUGIN_AUTHOR@"
+#define MyAppURL "https://obsproject.com/forum/resources/ptz-controls.1284/"
+
+[Setup]
+; NOTE: The value of AppId uniquely identifies this application.
+; Do not use the same AppId value in installers for other applications.
+; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
+AppId={{91164700-22BC-4204-9F2D-AA8D6986A602}
+AppName={#MyAppFullName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+DefaultDirName={commonappdata}\obs-studio\plugins\{#MyAppName}
+DefaultGroupName={#MyAppFullName}
+OutputBaseFilename={#MyAppName}-{#MyAppVersion}-Windows-Installer
+Compression=lzma
+SolidCompression=yes
+DirExistsWarning=no
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+Source: "..\release\Package\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\LICENSE"; Flags: dontcopy
+; NOTE: Don't use "Flags: ignoreversion" on any shared system files
+
+[Code]
+procedure InitializeWizard();
+var
+  GPLText: AnsiString;
+  Page: TOutputMsgMemoWizardPage;
+begin
+  ExtractTemporaryFile('LICENSE');
+  LoadStringFromFile(ExpandConstant('{tmp}\LICENSE'), GPLText);
+  Page := CreateOutputMsgMemoPage(wpWelcome,
+    'License Information', 'Please review the license terms before installing {#MyAppFullName}',
+    'Press Page Down to see the rest of the agreement. Once you are aware of your rights, click Next to continue.',
+    String(GPLText)
+  );
+end;


### PR DESCRIPTION
Reenables building an installer for the plugin, making use of the new OBS plugin install directory and directory layout.