### PR TITLE
visca: Fix crash on unresolved hostname

### DIFF
--- a/src/ptz-visca-udp.cpp
+++ b/src/ptz-visca-udp.cpp
@@ -169,7 +169,10 @@ void PTZViscaOverIP::send_immediate(const QByteArray &msg)
 
 void PTZViscaOverIP::lookup_host_callback(const QHostInfo info)
 {
-	auto new_addr = info.addresses().first();
+	auto addrs = info.addresses();
+	if (addrs.isEmpty())
+		return;
+	auto new_addr = addrs.first();
 	if (new_addr != ip_address) {
 		ip_address = new_addr;
 		reset();


### PR DESCRIPTION
The VISCA over UDP driver was unconditionally dereferencing an empty list when the lookup_host callback was triggered. When a hostname was resolved there was no problem, but on a lookup failure the addresses list is empty, and the function segfaulted. Fix by checking to see if the list isn't empty before dereferencing it.