### PR TITLE
Add brackets to min/max to avoid macro evaluation

### DIFF
--- a/shared/properties-view/properties-view.cpp
+++ b/shared/properties-view/properties-view.cpp
@@ -933,7 +933,7 @@ static bool matches_ranges(media_frames_per_second &best_match, media_frames_per
 	auto epsilon = make_epsilon(val);
 
 	bool match = false;
-	auto best_dist = numeric_limits<double>::max();
+	auto best_dist = (numeric_limits<double>::max)();
 	for (auto &pair : fps_ranges) {
 		auto max_ = convert_fn(pair.first);
 		auto min_ = convert_fn(pair.second);

--- a/src/touch-control.cpp
+++ b/src/touch-control.cpp
@@ -34,7 +34,7 @@ double TouchControl::y() const
 
 void TouchControl::setPosition(QPointF pos)
 {
-	double size = std::min(width(), height()) / 2;
+	double size = (std::min)(width(), height()) / 2;
 	double x = std::clamp((pos.x() - width() / 2) / size, -1.0, 1.0);
 	double y = -std::clamp((pos.y() - height() / 2) / size, -1.0, 1.0);
 	double mag = sqrt(x * x + y * y);
@@ -65,7 +65,7 @@ void TouchControl::paintEvent(QPaintEvent *event)
 
 	painter.setRenderHint(QPainter::Antialiasing);
 	painter.setPen(QPen(QBrush(Qt::gray), 0.01));
-	auto tsize = std::min(width(), height()) / 2;
+	auto tsize = (std::min)(width(), height()) / 2;
 	painter.translate(QPointF(width() / 2, height() / 2));
 	painter.scale(tsize, tsize);
 


### PR DESCRIPTION
Windows ARM64 indirectly includes windows.h via one of the headers, which defines macros for min/max. Putting brackets around the calls prevents macro evaluation.

Split out from #227 