### PR TITLE
Visca udp fixes

### DIFF
--- a/src/ptz-device.hpp
+++ b/src/ptz-device.hpp
@@ -18,7 +18,7 @@
 #include <util/platform.h>
 
 #define ptz_log(level, format, ...) \
-	blog(level, "[%s/%.12s] " format, type.c_str(), QT_TO_UTF8(objectName()), ##__VA_ARGS__)
+	blog(level, "[%s/%.12s] " format, this->type.c_str(), QT_TO_UTF8(this->objectName()), ##__VA_ARGS__)
 #define ptz_info(format, ...) ptz_log(LOG_INFO, format, ##__VA_ARGS__)
 #define ptz_debug(format, ...) ptz_log(LOG_DEBUG, format, ##__VA_ARGS__)
 #define ptz_debug_trace(format, ...) \

--- a/src/ptz-visca-udp.cpp
+++ b/src/ptz-visca-udp.cpp
@@ -189,8 +189,11 @@ void PTZViscaOverIP::set_config(OBSData config)
 	if (new_host != host) {
 		ip_address.clear();
 		host = new_host;
-		if (!host.isEmpty())
-			QHostInfo::lookupHost(host, this, SLOT(lookup_host_callback(QHostInfo)));
+		if (!host.isEmpty()) {
+			bool is_ip = ip_address.setAddress(host);
+			if (!is_ip)
+				QHostInfo::lookupHost(host, this, SLOT(lookup_host_callback(QHostInfo)));
+		}
 	}
 	if (!port)
 		port = 52381;


### PR DESCRIPTION
Fix long delay before VISCA UDP devices start working because the code was waiting on a reverse hostname lookup that wasn't needed.