### PR TITLE
Disable USB UVC on macos

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,7 +35,8 @@
         "CMAKE_OSX_ARCHITECTURES": "arm64;x86_64",
         "CODESIGN_IDENTITY": "$penv{CODESIGN_IDENT}",
         "CODESIGN_TEAM": "$penv{CODESIGN_TEAM}",
-        "ENABLE_SDL2_STATIC": true
+        "ENABLE_SDL2_STATIC": true,
+        "ENABLE_USB_CAM": false
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Features:
   - Pelco-P
   - Pelco-D
   - ONVIF (experimental)
+  - USB Cameras (Windows and Linux only)
 
 [OBS project resource page](https://obsproject.com/forum/resources/ptz-controls.1284/)
 


### PR DESCRIPTION
USB cameras are only supported on Windows and Linux. MacOS support hasn't been implemented yet, so remove it from the build.