### PR TITLE
ui: Fix layout of device list

### DIFF
--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -1155,11 +1155,10 @@ QSize PTZDeviceListDelegate::sizeHint(const QStyleOptionViewItem &option, const 
 {
 	QListView *tree = qobject_cast<QListView *>(parent());
 	QWidget *item = tree->indexWidget(index);
+	if (item)
+		return item->sizeHint();
 
-	if (!item)
-		return (QSize(0, 0));
-
-	return (QSize(option.widget->minimumWidth(), item->height()));
+	return QStyledItemDelegate::sizeHint(option, index);
 }
 
 void PTZDeviceListDelegate::initStyleOption(QStyleOptionViewItem *option, const QModelIndex &) const
@@ -1188,6 +1187,12 @@ PTZDeviceListItem::PTZDeviceListItem(PTZDevice *ptz_) : ptz(ptz_)
 	connect(lock, SIGNAL(clicked(bool)), PTZControls::getInstance(), SLOT(updateMoveControls()));
 
 	update();
+}
+
+QSize PTZDeviceListItem::sizeHint() const
+{
+	// The lock may be hidden, so account for it's size manually
+	return QFrame::sizeHint().expandedTo(lock->sizeHint());
 }
 
 void PTZDeviceListItem::update()

--- a/src/ptz-controls.hpp
+++ b/src/ptz-controls.hpp
@@ -225,6 +225,7 @@ public:
 	PTZDeviceListItem(PTZDevice *ptz_);
 	bool isLocked() { return lock ? lock->isChecked() && lock->isVisible() : false; };
 	void update();
+	virtual QSize sizeHint() const;
 
 private:
 	QSpacerItem *spacer = nullptr;


### PR DESCRIPTION
The device list QListView wasn't allocating enough space for the lock button on OBS Studio 31.1.0 beta due to the way sizeHint was getting calculated. It was using incorrect code copied from obs-studio that was fixed in commit dbee6d27, "frontend: Adjust styling for Sources list". This commit copies the corrected code over and adds a calculation to keep every row consistently sized for the lock button.