### PR TITLE
ui: Remove left and right margins from buttons

### DIFF
--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -149,6 +149,14 @@ PTZControls::PTZControls(QWidget *parent) : QFrame(parent), ui(new Ui::PTZContro
 {
 	instance = this;
 	ui->setupUi(this);
+
+	/* Compatability: Before OBS Studio 31.1.0 the theme had left and right
+	 * margins on widgets which mess with the grid layout used by this
+	 * plugin. If the version is earlier than 31.1.0 then apply an extra
+	 * style sheet to fix */
+	if (obs_get_version() < MAKE_SEMANTIC_VERSION(31, 1, 0))
+		this->setStyleSheet("margin-left: 0px; margin-right: 0px");
+
 	ui->cameraList->setModel(&ptzDeviceList);
 	ui->cameraList->setItemDelegate(new PTZDeviceListDelegate(ui->cameraList));
 	connect(&ptzDeviceList, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this,


### PR DESCRIPTION
In the 31.0.x OBS Studio series, the theme sets top and bottom margins on buttons to 0, but leaves the padding in place left and right. When laying out the buttons in a grid this makes the left and right gutters visibly larger than the top and bottom ones. Fix the problem by manually specifying a stylesheet for each grid button.

This problem doesn't exist in the latest 31.1.0 beta release. This is a temporary fix until support is dropped for 31.0.x.