### PR TITLE
Transition to proc handler API

### DIFF
--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -661,11 +661,6 @@ void PTZControls::setSpeedRampEnabled(bool enabled)
 	emit speedRampEnabledChanged(enabled);
 }
 
-PTZDevice *PTZControls::currCamera()
-{
-	return ptzDeviceList.getDevice(ui->cameraList->currentIndex());
-}
-
 bool PTZControls::callCurrentDevice(const char *method, calldata_t *cd)
 {
 	return ptzDeviceList.callDevice(ui->cameraList->currentIndex(), method, cd);

--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -666,29 +666,47 @@ PTZDevice *PTZControls::currCamera()
 	return ptzDeviceList.getDevice(ui->cameraList->currentIndex());
 }
 
+bool PTZControls::callCurrentDevice(const char *method, calldata_t *cd)
+{
+	return ptzDeviceList.callDevice(ui->cameraList->currentIndex(), method, cd);
+}
+
 void PTZControls::accelTimerHandler()
 {
-	PTZDevice *ptz = currCamera();
-	if (!ptz) {
+	calldata cd = {};
+	if (!ui->cameraList->currentIndex().isValid()) {
 		accel_timer.stop();
 		return;
 	}
 
-	pan_speed = std::clamp(pan_speed + pan_accel, -1.0, 1.0);
-	if (std::abs(pan_speed) == 1.0)
-		pan_accel = 0.0;
-	tilt_speed = std::clamp(tilt_speed + tilt_accel, -1.0, 1.0);
-	if (std::abs(tilt_speed) == 1.0)
-		tilt_accel = 0.0;
-	ptz->pantilt(pan_speed, tilt_speed);
-	zoom_speed = std::clamp(zoom_speed + zoom_accel, -1.0, 1.0);
-	if (std::abs(zoom_speed) == 1.0)
-		zoom_accel = 0.0;
-	ptz->zoom(zoom_speed);
-	focus_speed = std::clamp(focus_speed + focus_accel, -1.0, 1.0);
-	if (std::abs(focus_speed) == 1.0)
-		focus_accel = 0.0;
-	ptz->focus(focus_speed);
+	if (pan_accel || tilt_accel) {
+		pan_speed = std::clamp(pan_speed + pan_accel, -1.0, 1.0);
+		if (std::abs(pan_speed) == 1.0)
+			pan_accel = 0.0;
+		tilt_speed = std::clamp(tilt_speed + tilt_accel, -1.0, 1.0);
+		if (std::abs(tilt_speed) == 1.0)
+			tilt_accel = 0.0;
+		calldata_set_float(&cd, "pan", pan_speed);
+		calldata_set_float(&cd, "tilt", tilt_speed);
+	}
+
+	if (zoom_accel) {
+		zoom_speed = std::clamp(zoom_speed + zoom_accel, -1.0, 1.0);
+		if (std::abs(zoom_speed) == 1.0)
+			zoom_accel = 0.0;
+		calldata_set_float(&cd, "zoom", zoom_speed);
+	}
+
+	if (focus_accel) {
+		focus_speed = std::clamp(focus_speed + focus_accel, -1.0, 1.0);
+		if (std::abs(focus_speed) == 1.0)
+			focus_accel = 0.0;
+		calldata_set_float(&cd, "focus", focus_speed);
+	}
+
+	callCurrentDevice("move", &cd);
+	calldata_free(&cd);
+
 	if (pan_accel == 0.0 && tilt_accel == 0.0 && zoom_accel == 0.0 && focus_accel == 0.0)
 		accel_timer.stop();
 }
@@ -701,12 +719,14 @@ void PTZControls::setPanTilt(double pan, double tilt, double pan_accel_, double 
 	tilt_accel = tilt_accel_;
 	pantiltingFlag = pan != 0 || tilt != 0;
 
-	PTZDevice *ptz = currCamera();
-	if (!ptz)
-		return;
-	ptz->pantilt(pan, tilt);
 	if (pan_accel != 0 || tilt_accel != 0)
 		accel_timer.start(2000 / 20);
+
+	calldata cd = {};
+	calldata_set_float(&cd, "pan", pan_speed);
+	calldata_set_float(&cd, "tilt", tilt_speed);
+	callCurrentDevice("move", &cd);
+	calldata_free(&cd);
 }
 
 void PTZControls::keypressPanTilt(double pan, double tilt)
@@ -734,10 +754,6 @@ void PTZControls::keypressPanTilt(double pan, double tilt)
  */
 void PTZControls::setZoom(double zoom)
 {
-	PTZDevice *ptz = currCamera();
-	if (!ptz)
-		return;
-
 	auto modifiers = QGuiApplication::keyboardModifiers();
 	double speed = 0.5;
 	zoomingFlag = (zoom != 0.0);
@@ -746,15 +762,14 @@ void PTZControls::setZoom(double zoom)
 	else if (modifiers.testFlag(Qt::ShiftModifier))
 		speed = 0.1;
 
-	ptz->zoom(zoom * speed);
+	calldata cd = {};
+	calldata_set_float(&cd, "zoom", zoom * speed);
+	callCurrentDevice("move", &cd);
+	calldata_free(&cd);
 }
 
 void PTZControls::setFocus(double focus)
 {
-	PTZDevice *ptz = currCamera();
-	if (!ptz)
-		return;
-
 	auto modifiers = QGuiApplication::keyboardModifiers();
 	double speed = 0.5;
 	focusingFlag = (focus != 0.0);
@@ -763,7 +778,10 @@ void PTZControls::setFocus(double focus)
 	else if (modifiers.testFlag(Qt::ShiftModifier))
 		speed = 0.1;
 
-	ptz->focus(focus * speed);
+	calldata cd = {};
+	calldata_set_float(&cd, "focus", focus * speed);
+	callCurrentDevice("move", &cd);
+	calldata_free(&cd);
 }
 
 /* The pan/tilt buttons are a large block of simple and mostly identical code.
@@ -789,9 +807,7 @@ button_pantilt_actions(downright, 1, -1);
 
 void PTZControls::on_panTiltButton_home_released()
 {
-	PTZDevice *ptz = currCamera();
-	if (ptz)
-		ptz->pantilt_home();
+	callCurrentDevice("home");
 }
 
 void PTZControls::onHomeButtonContextMenu(const QPoint &pos)
@@ -801,11 +817,8 @@ void PTZControls::onHomeButtonContextMenu(const QPoint &pos)
 	QMenu menu(this);
 	QAction *setHome = menu.addAction(obs_module_text("PTZ.Action.SetHome"));
 	QAction *picked = menu.exec(ui->panTiltButton_home->mapToGlobal(pos));
-	if (picked == setHome) {
-		auto ptz = currCamera();
-		if (ptz)
-			ptz->pantilt_set_home();
-	}
+	if (picked == setHome)
+		callCurrentDevice("set_home");
 }
 
 /* There are fewer buttons for zoom or focus; so don't bother with macros */
@@ -832,9 +845,10 @@ void PTZControls::on_zoomButton_wide_released()
 void PTZControls::on_focusButton_auto_clicked(bool checked)
 {
 	setAutofocusEnabled(checked);
-	PTZDevice *ptz = currCamera();
-	if (ptz)
-		ptz->set_autofocus(checked);
+	calldata cd = {};
+	calldata_set_bool(&cd, "autofocus", checked);
+	callCurrentDevice("set", &cd);
+	calldata_free(&cd);
 }
 
 void PTZControls::on_focusButton_near_pressed()
@@ -859,9 +873,7 @@ void PTZControls::on_focusButton_far_released()
 
 void PTZControls::on_focusButton_onetouch_clicked()
 {
-	PTZDevice *ptz = currCamera();
-	if (ptz)
-		ptz->focus_onetouch();
+	callCurrentDevice("focus_onetouch");
 }
 
 void PTZControls::setAutofocusEnabled(bool autofocus_on)
@@ -888,15 +900,10 @@ void PTZControls::currentChanged(QModelIndex current, QModelIndex previous)
 {
 	PTZDevice *ptz = ptzDeviceList.getDevice(previous);
 	accel_timer.stop();
-	if (ptz) {
+	if (ptz)
 		disconnect(ptz, nullptr, this, nullptr);
-		if (pantiltingFlag)
-			ptz->pantilt(0, 0);
-		if (zoomingFlag)
-			ptz->zoom(0);
-		if (focusingFlag)
-			ptz->focus(0);
-	}
+	if (pantiltingFlag || zoomingFlag || focusingFlag)
+		ptzDeviceList.callDevice(previous, "stop");
 	pantiltingFlag = false;
 	zoomingFlag = false;
 	focusingFlag = false;
@@ -929,18 +936,26 @@ void PTZControls::settingsChanged(OBSData settings)
 
 void PTZControls::presetSet(int preset_id)
 {
-	PTZDevice *ptz = currCamera();
-	if (!ptz)
-		return;
-	ptz->memory_set(preset_id);
+	calldata cd = {};
+	calldata_set_int(&cd, "preset_id", preset_id);
+	callCurrentDevice("preset_save", &cd);
+	calldata_free(&cd);
 }
 
 void PTZControls::presetRecall(int preset_id)
 {
-	PTZDevice *ptz = currCamera();
-	if (!ptz)
-		return;
-	ptz->memory_recall(preset_id);
+	calldata cd = {};
+	calldata_set_int(&cd, "preset_id", preset_id);
+	callCurrentDevice("preset_recall", &cd);
+	calldata_free(&cd);
+}
+
+void PTZControls::presetReset(int preset_id)
+{
+	calldata cd = {};
+	calldata_set_int(&cd, "preset_id", preset_id);
+	callCurrentDevice("preset_clear", &cd);
+	calldata_free(&cd);
 }
 
 int PTZControls::presetIndexToId(QModelIndex index)
@@ -1110,20 +1125,18 @@ void PTZControls::on_actionPresetSave_triggered()
 {
 	auto model = ui->presetListView->model();
 	auto index = ui->presetListView->currentIndex();
-	PTZDevice *ptz = currCamera();
-	if (!model || !index.isValid() || !ptz)
+	if (!model || !index.isValid())
 		return;
-	ptz->memory_set(presetIndexToId(index));
+	presetSet(presetIndexToId(index));
 }
 
 void PTZControls::on_actionPresetClear_triggered()
 {
 	auto model = ui->presetListView->model();
 	auto index = ui->presetListView->currentIndex();
-	PTZDevice *ptz = currCamera();
-	if (!model || !index.isValid() || !ptz)
+	if (!model || !index.isValid())
 		return;
-	ptz->memory_reset(presetIndexToId(index));
+	presetReset(presetIndexToId(index));
 	ui->presetListView->model()->setData(index, "");
 }
 

--- a/src/ptz-controls.hpp
+++ b/src/ptz-controls.hpp
@@ -77,7 +77,6 @@ private:
 	void presetReset(int id);
 	void setAutofocusEnabled(bool autofocus_on);
 
-	PTZDevice *currCamera();
 	bool callCurrentDevice(const char *method, calldata_t *cd = nullptr);
 
 	QList<obs_hotkey_id> hotkeys;

--- a/src/ptz-controls.hpp
+++ b/src/ptz-controls.hpp
@@ -74,9 +74,11 @@ private:
 	int presetIndexToId(QModelIndex index);
 	void presetSet(int id);
 	void presetRecall(int id);
+	void presetReset(int id);
 	void setAutofocusEnabled(bool autofocus_on);
 
 	PTZDevice *currCamera();
+	bool callCurrentDevice(const char *method, calldata_t *cd = nullptr);
 
 	QList<obs_hotkey_id> hotkeys;
 	QMap<obs_hotkey_id, int> preset_hotkey_map;

--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -154,6 +154,12 @@ QStringList PTZListModel::getDeviceNames() const
 	return names;
 }
 
+bool PTZListModel::callDevice(const QModelIndex &index, const char *method, calldata_t *cd)
+{
+	auto ptz = getDevice(index);
+	return ptz ? proc_handler_call(ptz->handler, method, cd) : false;
+}
+
 QModelIndex PTZListModel::indexFromDeviceId(uint32_t device_id)
 {
 	auto ptz = getDevice(device_id);
@@ -486,8 +492,58 @@ OBSDataArray PTZPresetListModel::savePresets() const
 	return preset_array.Get();
 }
 
+/**
+ * Lambda factory macro for the PTZ proc_handler methods. This macro
+ * simplifies the registration of PTZDevice methods as targets for
+ * proc_handler calls.
+ *
+ * In this current implementation, the proc_handler must be called from
+ * the GUI thread. If called from another thread it will output a
+ * warning and return without action. It is done this way because the
+ * calldata_t* is transient and owned by the calling thread, but Qt
+ * objects need to be called from their own thread, and calldata would
+ * be stale if the call was queued with QMetaObject::invokeMethod()
+ *
+ * This isn't ideal, as there are places where other plugins may want to
+ * make calls from their own threads. The rule can be relaxed on a call
+ * by call basis if the method is made thread safe.
+ */
+#define ptz_ph_lambda(_method) [](void *p, calldata_t *cd) \
+	{ \
+		auto ptz = static_cast<PTZDevice *>(p); \
+		if (!ptz) { \
+			blog(LOG_ERROR, "PTZ proc_handler called without PTZDevice pointer"); \
+			return; \
+		} \
+		if (QThread::currentThread() != ptz->thread()) { \
+			blog(LOG_WARNING, "PTZDevice proc_handler '%s'->%s() call from non-GUI thread; ignored", QT_TO_UTF8(ptz->objectName()), #_method); \
+			return; \
+		} \
+		ptz->_method(cd); \
+	}
+
 PTZDevice::PTZDevice(OBSData config) : QObject()
 {
+	/* Create and populate the proc handler methods */
+	handler = proc_handler_create();
+	if (!handler) {
+		blog(LOG_ERROR, "could not allocate proc_handler for %s", obs_data_get_string(config, "name"));
+		return;
+	}
+
+	proc_handler_add(handler, "void stop()", ptz_ph_lambda(stop), this);
+	proc_handler_add(handler, "void home()", ptz_ph_lambda(pantilt_home), this);
+	proc_handler_add(handler, "void set_home()", ptz_ph_lambda(pantilt_set_home), this);
+	// Pan/tilt/zoom/focus operations
+	proc_handler_add(handler, "void move()", ptz_ph_lambda(move), this);
+	proc_handler_add(handler, "void move_abs()", ptz_ph_lambda(move_abs), this);
+	proc_handler_add(handler, "void move_rel()", ptz_ph_lambda(move_rel), this);
+	proc_handler_add(handler, "void set()", ptz_ph_lambda(set), this);
+	proc_handler_add(handler, "void focus_onetouch()", ptz_ph_lambda(focus_onetouch), this);
+	proc_handler_add(handler, "void preset_save()", ptz_ph_lambda(preset_save), this);
+	proc_handler_add(handler, "void preset_recall()", ptz_ph_lambda(preset_recall), this);
+	proc_handler_add(handler, "void preset_clear()", ptz_ph_lambda(preset_clear), this);
+
 	setObjectName(obs_data_get_string(config, "name"));
 	id = (int)obs_data_get_int(config, "id");
 	type = obs_data_get_string(config, "type");
@@ -503,6 +559,8 @@ PTZDevice::PTZDevice(OBSData config) : QObject()
 PTZDevice::~PTZDevice()
 {
 	ptzDeviceList.remove(this);
+	proc_handler_destroy(handler);
+	handler = nullptr;
 }
 
 void PTZDevice::setObjectName(QString name)
@@ -549,6 +607,13 @@ void PTZDevice::onSceneChanged()
 	}
 }
 
+void PTZDevice::stop()
+{
+	pantilt(0, 0);
+	zoom(0);
+	focus(0);
+}
+
 void PTZDevice::pantilt(double pan, double tilt)
 {
 	pan = std::clamp(pan * (pan_invert ? -1 : 1), -pantilt_speed_max, pantilt_speed_max);
@@ -579,6 +644,70 @@ void PTZDevice::focus(double speed)
 	focus_speed = speed;
 	focus_changed = true;
 	do_update();
+}
+
+void PTZDevice::move(calldata_t *cd)
+{
+	double p = 0, t = 0, z = 0, f = 0;
+
+	if (calldata_get_float(cd, "pan", &p) + calldata_get_float(cd, "tilt", &t))
+		pantilt(p, t);
+
+	if (calldata_get_float(cd, "zoom", &z))
+		zoom(z);
+
+	if (calldata_get_float(cd, "focus", &f))
+		focus(f);
+}
+
+void PTZDevice::move_abs(calldata_t *cd)
+{
+	double p = 0, t = 0, z = 0, f = 0;
+
+	if (calldata_get_float(cd, "pan", &p) + calldata_get_float(cd, "tilt", &t))
+		pantilt_abs(p, t);
+
+	if (calldata_get_float(cd, "zoom", &z))
+		zoom_abs(z);
+
+	if (calldata_get_float(cd, "focus", &f))
+		focus_abs(f);
+}
+
+void PTZDevice::move_rel(calldata_t *cd)
+{
+	double p = 0, t = 0;
+
+	if (calldata_get_float(cd, "pan", &p) + calldata_get_float(cd, "tilt", &t))
+		pantilt_rel(p, t);
+}
+
+void PTZDevice::set(calldata_t *cd)
+{
+	bool enable;
+	if (calldata_get_bool(cd, "autofocus", &enable))
+		set_autofocus(enable);
+}
+
+void PTZDevice::preset_save(calldata_t *cd)
+{
+	long long id;
+	if (calldata_get_int(cd, "preset_id", &id))
+		memory_set(id);
+}
+
+void PTZDevice::preset_recall(calldata_t *cd)
+{
+	long long id;
+	if (calldata_get_int(cd, "preset_id", &id))
+		memory_recall(id);
+}
+
+void PTZDevice::preset_clear(calldata_t *cd)
+{
+	long long id;
+	if (calldata_get_int(cd, "preset_id", &id))
+		memory_reset(id);
 }
 
 void PTZDevice::set_config(OBSData config)

--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -154,9 +154,23 @@ QStringList PTZListModel::getDeviceNames() const
 	return names;
 }
 
+/**
+ * This variant of callDevice accepts a QModelIndex into the data model
+ * to choose which device will receive the call
+ */
 bool PTZListModel::callDevice(const QModelIndex &index, const char *method, calldata_t *cd)
 {
 	auto ptz = getDevice(index);
+	return ptz ? proc_handler_call(ptz->handler, method, cd) : false;
+}
+
+/**
+ * This variant of callDevice extracts the device_id from calldata
+ * before calling the device's proc handler.
+ */
+bool PTZListModel::callDevice(const char *method, calldata_t *cd)
+{
+	auto ptz = getDevice(calldata_int(cd, "device_id"));
 	return ptz ? proc_handler_call(ptz->handler, method, cd) : false;
 }
 
@@ -314,27 +328,6 @@ void PTZListModel::preset_save(uint32_t device_id, int preset_id)
 	PTZDevice *ptz = ptzDeviceList.getDevice(device_id);
 	if (ptz)
 		ptz->memory_set(preset_id);
-}
-
-enum {
-	MOVE_FLAG_PANTILT = 1 << 0,
-	MOVE_FLAG_ZOOM = 1 << 1,
-	MOVE_FLAG_FOCUS = 1 << 2,
-};
-
-void PTZListModel::move_continuous(uint32_t device_id, uint32_t flags, double pan, double tilt, double zoom,
-				   double focus)
-{
-	PTZDevice *ptz = ptzDeviceList.getDevice(device_id);
-	if (!ptz)
-		return;
-
-	if (flags & MOVE_FLAG_PANTILT)
-		ptz->pantilt(pan, tilt);
-	if (flags & MOVE_FLAG_ZOOM)
-		ptz->zoom(zoom);
-	if (flags & MOVE_FLAG_FOCUS)
-		ptz->focus(focus);
 }
 
 int PTZPresetListModel::rowCount(const QModelIndex &parent) const
@@ -876,36 +869,15 @@ void ptz_load_devices()
 		return;
 
 	/* Preset Recall/Save Callback */
-	auto ptz_preset_cb = [](void *data, calldata_t *cd) {
-		auto function = static_cast<const char *>(data);
-		QMetaObject::invokeMethod(&ptzDeviceList, function, Q_ARG(uint32_t, calldata_int(cd, "device_id")),
-					  Q_ARG(int, calldata_int(cd, "preset_id")));
+	auto ptz_cb = [](void *p, calldata_t *cd) {
+		ptzDeviceList.callDevice(static_cast<const char *>(p), cd);
 	};
-	proc_handler_add(ptz_ph, "void ptz_preset_recall(int device_id, int preset_id)", ptz_preset_cb,
+	proc_handler_add(ptz_ph, "void ptz_preset_save(int device_id, int preset_id)", ptz_cb, (void *)"preset_save");
+	proc_handler_add(ptz_ph, "void ptz_preset_recall(int device_id, int preset_id)", ptz_cb,
 			 (void *)"preset_recall");
-	proc_handler_add(ptz_ph, "void ptz_preset_save(int device_id, int preset_id)", ptz_preset_cb,
-			 (void *)"preset_save");
-
-	auto ptz_move_continuous = [](void *data, calldata_t *cd) {
-		Q_UNUSED(data);
-		long long device_id;
-		double pan, tilt, zoom, focus;
-		if (!calldata_get_int(cd, "device_id", &device_id))
-			return;
-		int flags = 0;
-		if (calldata_get_float(cd, "pan", &pan) && calldata_get_float(cd, "tilt", &tilt))
-			flags |= MOVE_FLAG_PANTILT;
-		if (calldata_get_float(cd, "zoom", &zoom))
-			flags |= MOVE_FLAG_ZOOM;
-		if (calldata_get_float(cd, "focus", &focus))
-			flags |= MOVE_FLAG_FOCUS;
-		QMetaObject::invokeMethod(&ptzDeviceList, "move_continuous", Q_ARG(uint32_t, device_id),
-					  Q_ARG(uint32_t, flags), Q_ARG(double, pan), Q_ARG(double, tilt),
-					  Q_ARG(double, zoom), Q_ARG(double, focus));
-	};
 	proc_handler_add(ptz_ph,
 			 "void ptz_move_continuous(int device_id, float pan, float tilt, float zoom, float focus)",
-			 ptz_move_continuous, NULL);
+			 ptz_cb, (void *)"move");
 
 	/* Register the new proc hander with the main proc handler */
 	proc_handler_t *ph = obs_get_proc_handler();
@@ -913,15 +885,14 @@ void ptz_load_devices()
 		return;
 
 	/* Register a function for retrieving the PTZ call handler */
-	auto ptz_get_proc_handler = [](void *data, calldata_t *cd) {
-		Q_UNUSED(data);
+	auto ptz_get_proc_handler = [](void *, calldata_t *cd) {
 		calldata_set_ptr(cd, "return", ptz_ph);
 	};
 	proc_handler_add(ph, "ptr ptz_get_proc_handler()", ptz_get_proc_handler, NULL);
 
 	/* Deprecated pantilt callback for compatibility with existing plugins */
-	proc_handler_add(ph, "void ptz_pantilt(int device_id, float pan, float tilt, float zoom, float focus)",
-			 ptz_move_continuous, NULL);
+	proc_handler_add(ph, "void ptz_pantilt(int device_id, float pan, float tilt, float zoom, float focus)", ptz_cb,
+			 (void *)"move");
 }
 
 void ptz_unload_devices(void)

--- a/src/ptz-device.hpp
+++ b/src/ptz-device.hpp
@@ -61,6 +61,7 @@ public:
 	PTZDevice *getDevice(uint32_t device_id) const;
 	PTZDevice *getDeviceByName(const QString &name) const;
 	QStringList getDeviceNames() const;
+	bool callDevice(const QModelIndex &index, const char *method, calldata_t *cd = nullptr);
 	QModelIndex indexFromDeviceId(uint32_t device_id);
 	QModelIndex indexFromName(const QString &name);
 	void renameDevice(QString new_name, QString prev_name);
@@ -147,6 +148,10 @@ protected:
 	QSet<QString> stale_settings;
 	void incrementStatistic(const char *name);
 
+	// Each PTZ device has a proc handler so methods can be called
+	// from other plugins
+	proc_handler_t *handler = nullptr;
+
 signals:
 	void settingsChanged(OBSData settings);
 	void connectionStatusChanged(bool connected);
@@ -197,6 +202,8 @@ public:
 	 * zoom: range[0.0, 1.0], 0.0 == wide angle, 1.0 == telephoto
 	 * focus: range[0.0, 1.0], 0.0 == far focus, 1.0 == near focus
 	 */
+protected:
+	void stop();
 	void pantilt(double pan, double tilt);
 	virtual void pantilt_rel(double pan, double tilt)
 	{
@@ -227,6 +234,21 @@ public:
 	virtual void memory_set(int i) { Q_UNUSED(i); }
 	virtual void memory_recall(int i) { Q_UNUSED(i); }
 	virtual void memory_reset(int i) { Q_UNUSED(i); }
+
+protected slots:
+	void stop(calldata_t *) { stop(); }
+	void pantilt_home(calldata_t *) { pantilt_home(); }
+	void pantilt_set_home(calldata_t *) { pantilt_set_home(); };
+	void move(calldata_t *cd);
+	void move_abs(calldata_t *cd);
+	void move_rel(calldata_t *cd);
+	virtual void set(calldata_t *cd);
+	void focus_onetouch(calldata_t *) { focus_onetouch(); }
+	void preset_save(calldata_t *cd);
+	void preset_recall(calldata_t *cd);
+	void preset_clear(calldata_t *cd);
+
+public:
 	virtual QAbstractListModel *presetModel() { return &m_presetsModel; }
 	bool isLocked() const { return locked; };
 	bool isConnected() const { return connected; }

--- a/src/ptz-device.hpp
+++ b/src/ptz-device.hpp
@@ -62,6 +62,7 @@ public:
 	PTZDevice *getDeviceByName(const QString &name) const;
 	QStringList getDeviceNames() const;
 	bool callDevice(const QModelIndex &index, const char *method, calldata_t *cd = nullptr);
+	bool callDevice(const char *method, calldata_t *cd = nullptr);
 	QModelIndex indexFromDeviceId(uint32_t device_id);
 	QModelIndex indexFromName(const QString &name);
 	void renameDevice(QString new_name, QString prev_name);
@@ -74,7 +75,6 @@ public:
 public slots:
 	void preset_recall(uint32_t device_id, int preset_id);
 	void preset_save(uint32_t device_id, int preset_id);
-	void move_continuous(uint32_t device_id, uint32_t flags, double pan, double tilt, double zoom, double focus);
 };
 
 extern PTZListModel ptzDeviceList;


### PR DESCRIPTION
This series reworks the camera interface to go though a proc_handler API in a step towards other plugins being able to provide a PTZ interface controlled by the PTZ panel.

This series is a WIP. The work is not complete as there are still several places where the UI frontend directly accesses the PTZDevice* instances. More work is needed to change the slots/signals connections into OBS signal handlers.