### PR TITLE
ptz-controls: save config from obs_module_unload, not destructor

### DIFF
--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -72,6 +72,12 @@ public:
 void PTZControls::OBSFrontendEventWrapper(enum obs_frontend_event event, void *ptr)
 {
 	PTZControls *controls = reinterpret_cast<PTZControls *>(ptr);
+	if (event == OBS_FRONTEND_EVENT_EXIT) {
+		/* Must run synchronously; the event loop may not drain
+		 * queued events during shutdown. */
+		controls->OBSFrontendEvent(event);
+		return;
+	}
 	QMetaObject::invokeMethod(
 		controls, [controls, event]() { controls->OBSFrontendEvent(event); }, Qt::QueuedConnection);
 }
@@ -81,6 +87,14 @@ void PTZControls::OBSFrontendEvent(enum obs_frontend_event event)
 	obs_source_t *scene = NULL;
 
 	switch (event) {
+	case OBS_FRONTEND_EVENT_EXIT:
+		/* Save config here: obs APIs are still valid and the
+		 * widget is still alive on all platforms. */
+		SaveConfig();
+		while (!hotkeys.isEmpty())
+			obs_hotkey_unregister(hotkeys.takeFirst());
+		ptzDeviceList.delete_all();
+		return;
 	case OBS_FRONTEND_EVENT_TRANSITION_STOPPED:
 		updateMoveControls();
 		break;
@@ -312,11 +326,7 @@ PTZControls::PTZControls(QWidget *parent) : QFrame(parent), ui(new Ui::PTZContro
 
 PTZControls::~PTZControls()
 {
-	while (!hotkeys.isEmpty())
-		obs_hotkey_unregister(hotkeys.takeFirst());
-
-	SaveConfig();
-	ptzDeviceList.delete_all();
+	instance = NULL;
 	deleteLater();
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -494,7 +494,9 @@ void PTZSettings::showDevice(const QModelIndex &index)
 static void obs_event(enum obs_frontend_event event, void *)
 {
 	if (event == OBS_FRONTEND_EVENT_EXIT && ptzSettingsWindow) {
-		ptzSettingsWindow->deleteLater();
+		/* Destroy synchronously; deleteLater() may not run before
+		 * libobs shuts down, causing crashes on teardown. */
+		delete ptzSettingsWindow;
 		ptzSettingsWindow = nullptr;
 	}
 }


### PR DESCRIPTION
﻿:robot: (Copilot CLI on Sam's behalf)

Fixes a SIGSEGV / access-violation crash that occurs on OBS shutdown for users running obs-ptz, and resolves the related symptom where PTZ presets and settings are silently lost on exit.

## Root cause

`PTZControls::~PTZControls()` calls `SaveConfig()` → `obs_module_config_path("config.json")` → `obs_module_get_config_path(obs_current_module(), file)`.

By the time Qt destroys the dock widget during shutdown, libobs has already run `free_module()` and nulled this module's `obs_module_pointer`. The destructor dereferences NULL and crashes.

On Linux this manifests as a SIGSEGV. On Windows it's an access violation (0xc0000005) in `obs.dll!obs_module_get_config_path`.

## Fix

1. **Event-based config save** (`ptz-controls.cpp`): Register an `OBS_FRONTEND_EVENT_EXIT` handler that calls `SaveConfig()` and tears down devices while `obs_current_module()` is still valid.
2. **Synchronous dialog destruction** (`settings.cpp`): Destroy the PTZ Settings dialog with `delete` rather than `deleteLater()` in the EXIT handler, ensuring cleanup completes before module unload begins.

Together these ensure all obs-ptz state is saved and all resources released before libobs invalidates the module pointer.

## Cross-platform testing

| Platform | Before (v0.18.2) | After (this PR) |
|----------|-------------------|-----------------|
| **Linux** (Mint 22.3 / OBS 32.1.2) | SIGSEGV on every exit | 5/5 PASS, clean exit |
| **macOS** (Mac mini M4 / OBS 32.1.2) | No crash (unaffected) | 5/5 PASS, no regression |
| **Windows** (Win11 / OBS 32.1.2) | Access violation crash | 5/5 PASS, crash eliminated |

### Windows shutdown hang (separate issue)

On Windows, a *separate* deadlock exists in obs-browser.dll where `manager_thread.join()` blocks the main thread's STA message pump during `CefShutdown()`. This is unrelated to obs-ptz and occurs regardless of whether this PR is applied. Analysis and a proposed fix (replacing the blocking join with a `MsgWaitForMultipleObjects` pump loop) are available at [sammallon/obs-browser@fix/win-shutdown-deadlock](https://github.com/sammallon/obs-browser/tree/fix/win-shutdown-deadlock). Submitting this upstream to obs-browser will require a contributor familiar with CEF/COM threading to champion it, as the obsproject repos do not accept AI-assisted submissions.

## Closes

- Closes #274

## Notes

- macOS support was specifically validated per maintainer feedback on the event-based approach.
- Patch authored with help from GitHub Copilot CLI; full review and testing by Sam.
