### PR TITLE
Decouple settings dialog from PTZDevice

### DIFF
--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -128,6 +128,8 @@ void PTZListModel::onSceneChanged()
 
 PTZDevice *PTZListModel::getDevice(const QModelIndex &index) const
 {
+	if (!index.isValid() || index.model() != this)
+		return nullptr;
 	return devices.value(index.row());
 }
 

--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -194,6 +194,13 @@ void PTZListModel::add(PTZDevice *ptz)
 	do_reset();
 }
 
+void PTZListModel::removeDevice(const QModelIndex &index)
+{
+	PTZDevice *ptz = getDevice(index);
+	if (ptz)
+		delete ptz;
+}
+
 void PTZListModel::remove(PTZDevice *ptz)
 {
 	devicesById.remove(ptz->getId());

--- a/src/ptz-device.hpp
+++ b/src/ptz-device.hpp
@@ -65,6 +65,7 @@ public:
 	QModelIndex indexFromName(const QString &name);
 	void renameDevice(QString new_name, QString prev_name);
 	obs_data_array_t *getConfigs();
+	void removeDevice(const QModelIndex &index);
 	void add(PTZDevice *ptz);
 	void remove(PTZDevice *ptz);
 	void delete_all();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -429,10 +429,7 @@ void PTZSettings::on_addPTZ_clicked()
 
 void PTZSettings::on_removePTZ_clicked()
 {
-	PTZDevice *ptz = ptzDeviceList.getDevice(ui->deviceList->currentIndex());
-	if (!ptz)
-		return;
-	delete ptz;
+	ptzDeviceList.removeDevice(ui->deviceList->currentIndex());
 }
 
 void PTZSettings::on_applyButton_clicked()

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -35,14 +35,33 @@ static PTZSettings *ptzSettingsWindow = nullptr;
 
 /* ----------------------------------------------------------------- */
 
-QString SourceNameDelegate::displayText(const QVariant &value, const QLocale &locale) const
-{
-	auto string = QStyledItemDelegate::displayText(value, locale);
-	auto ptz = ptzDeviceList.getDeviceByName(string);
-	if (ptz)
-		return ptz->description() + " - " + string;
-	return string;
-}
+class SourceNameDelegate : public QStyledItemDelegate {
+	Q_DISABLE_COPY(SourceNameDelegate)
+
+public:
+	using QStyledItemDelegate::QStyledItemDelegate;
+	void fixName(QStyleOptionViewItem *opt, const QModelIndex &index) const
+	{
+		initStyleOption(opt, index);
+		opt->text = opt->text + " [" + index.data(PTZListModel::DescriptionRole).toString() + "]";
+	}
+	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override
+	{
+		Q_ASSERT(index.isValid());
+		QStyleOptionViewItem opt = option;
+		fixName(&opt, index);
+		QStyle *style = option.widget ? option.widget->style() : QApplication::style();
+		style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, option.widget);
+	}
+	QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override
+	{
+		Q_ASSERT(index.isValid());
+		QStyleOptionViewItem opt = option;
+		fixName(&opt, index);
+		QStyle *style = option.widget ? option.widget->style() : QApplication::style();
+		return style->sizeFromContents(QStyle::CT_ItemViewItem, &opt, QSize(), option.widget);
+	}
+};
 
 obs_properties_t *PTZSettings::getProperties(void)
 {

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -35,14 +35,6 @@ protected:
 };
 #endif
 
-class SourceNameDelegate : public QStyledItemDelegate {
-	Q_OBJECT
-
-public:
-	SourceNameDelegate(QObject *parent = nullptr) : QStyledItemDelegate(parent) {};
-	virtual QString displayText(const QVariant &value, const QLocale &locale) const;
-};
-
 class PTZSettings : public QWidget {
 	Q_OBJECT
 


### PR DESCRIPTION
Fixes to further reduce coupling between the settings dialog and PTZDevice*. With these changes the settings dialog relies more heavily on the PTZListModel for getting data about each device.