### PR TITLE
Fix PTZ action commands getting ignored

### DIFF
--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -409,8 +409,8 @@ static obs_hotkey_id lookup_obs_hotkey_id(QString hotkey_name)
 	obs_enum_hotkeys(
 		[](void *data, obs_hotkey_id id, obs_hotkey_t *key) {
 			data_t &d = *static_cast<data_t *>(data);
-			if (get<0>(d) == obs_hotkey_get_name(key)) {
-				*get<1>(d) = id;
+			if (std::get<0>(d) == obs_hotkey_get_name(key)) {
+				*std::get<1>(d) = id;
 				return false;
 			}
 			return true;

--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -35,10 +35,6 @@
 			blog(LOG_ERROR, "PTZ proc_handler called without PTZDevice pointer"); \
 			return; \
 		} \
-		if (QThread::currentThread() != ptz->thread()) { \
-			blog(LOG_WARNING, "PTZDevice proc_handler '%s'->%s() call from non-GUI thread; ignored", QT_TO_UTF8(ptz->objectName()), #_method); \
-			return; \
-		} \
 		ptz->_method(cd); \
 	}
 
@@ -172,13 +168,13 @@ void PTZDevice::move(calldata_t *cd)
 	double p = 0, t = 0, z = 0, f = 0;
 
 	if (calldata_get_float(cd, "pan", &p) + calldata_get_float(cd, "tilt", &t))
-		pantilt(p, t);
+		QMetaObject::invokeMethod(this, "pantilt", Q_ARG(double, p), Q_ARG(double, t));
 
 	if (calldata_get_float(cd, "zoom", &z))
-		zoom(z);
+		QMetaObject::invokeMethod(this, "zoom", Q_ARG(double, z));
 
 	if (calldata_get_float(cd, "focus", &f))
-		focus(f);
+		QMetaObject::invokeMethod(this, "focus", Q_ARG(double, f));
 }
 
 void PTZDevice::move_abs(calldata_t *cd)
@@ -186,13 +182,13 @@ void PTZDevice::move_abs(calldata_t *cd)
 	double p = 0, t = 0, z = 0, f = 0;
 
 	if (calldata_get_float(cd, "pan", &p) + calldata_get_float(cd, "tilt", &t))
-		pantilt_abs(p, t);
+		QMetaObject::invokeMethod(this, "pantilt_abs", Q_ARG(double, p), Q_ARG(double, t));
 
 	if (calldata_get_float(cd, "zoom", &z))
-		zoom_abs(z);
+		QMetaObject::invokeMethod(this, "zoom_abs", Q_ARG(double, z));
 
 	if (calldata_get_float(cd, "focus", &f))
-		focus_abs(f);
+		QMetaObject::invokeMethod(this, "focus_abs", Q_ARG(double, f));
 }
 
 void PTZDevice::move_rel(calldata_t *cd)
@@ -200,11 +196,15 @@ void PTZDevice::move_rel(calldata_t *cd)
 	double p = 0, t = 0;
 
 	if (calldata_get_float(cd, "pan", &p) + calldata_get_float(cd, "tilt", &t))
-		pantilt_rel(p, t);
+		QMetaObject::invokeMethod(this, "pantilt_rel", Q_ARG(double, p), Q_ARG(double, t));
 }
 
 void PTZDevice::get(calldata_t *cd) const
 {
+	if (QThread::currentThread() != thread()) {
+		ptz_log(LOG_ERROR, "PTZDevice::get(calldata) called from non-GUI thread; ignored");
+		return;
+	}
 	QString arg = calldata_string(cd, "property");
 	if (arg == "power_on")
 		calldata_set_bool(cd, "power_on", obs_data_get_bool(settings, "power_on"));
@@ -217,31 +217,31 @@ void PTZDevice::set(calldata_t *cd)
 {
 	bool enable;
 	if (calldata_get_bool(cd, "focus_af_enabled", &enable))
-		set_autofocus(enable);
+		QMetaObject::invokeMethod(this, "set_autofocus", Q_ARG(bool, enable));
 	bool trigger;
 	if (calldata_get_bool(cd, "focus_onetouch_trigger", &trigger) && trigger)
-		focus_onetouch();
+		QMetaObject::invokeMethod(this, &PTZDevice::focus_onetouch);
 }
 
 void PTZDevice::preset_save(calldata_t *cd)
 {
 	long long id;
 	if (calldata_get_int(cd, "preset_id", &id))
-		memory_set(id);
+		QMetaObject::invokeMethod(this, "memory_set", Q_ARG(int, id));
 }
 
 void PTZDevice::preset_recall(calldata_t *cd)
 {
 	long long id;
 	if (calldata_get_int(cd, "preset_id", &id))
-		memory_recall(id);
+		QMetaObject::invokeMethod(this, "memory_recall", Q_ARG(int, id));
 }
 
 void PTZDevice::preset_clear(calldata_t *cd)
 {
 	long long id;
 	if (calldata_get_int(cd, "preset_id", &id))
-		memory_reset(id);
+		QMetaObject::invokeMethod(this, "memory_reset", Q_ARG(int, id));
 }
 
 void PTZDevice::getDefaults(OBSData config) const

--- a/src/ptz-device.hpp
+++ b/src/ptz-device.hpp
@@ -109,7 +109,7 @@ public:
 	 * zoom: range[0.0, 1.0], 0.0 == wide angle, 1.0 == telephoto
 	 * focus: range[0.0, 1.0], 0.0 == far focus, 1.0 == near focus
 	 */
-protected:
+protected slots:
 	void stop();
 	void pantilt(double pan, double tilt);
 	virtual void pantilt_rel(double pan, double tilt)
@@ -142,10 +142,9 @@ protected:
 	virtual void memory_recall(int i) { Q_UNUSED(i); }
 	virtual void memory_reset(int i) { Q_UNUSED(i); }
 
-protected slots:
-	void stop(calldata_t *) { stop(); }
-	void pantilt_home(calldata_t *) { pantilt_home(); }
-	void pantilt_set_home(calldata_t *) { pantilt_set_home(); };
+	void stop(calldata_t *) { QMetaObject::invokeMethod(this, "stop"); }
+	void pantilt_home(calldata_t *) { QMetaObject::invokeMethod(this, "pantilt_home"); }
+	void pantilt_set_home(calldata_t *) { QMetaObject::invokeMethod(this, "pantilt_set_home"); }
 	void move(calldata_t *cd);
 	void move_abs(calldata_t *cd);
 	void move_rel(calldata_t *cd);

--- a/src/ptz-visca.cpp
+++ b/src/ptz-visca.cpp
@@ -780,6 +780,10 @@ void PTZVisca::receive(const QByteArray &msg)
 
 void PTZVisca::get(calldata_t *cd) const
 {
+	if (QThread::currentThread() != thread()) {
+		ptz_log(LOG_ERROR, "PTZVisca::get(calldata) called from non-GUI thread; ignored");
+		return;
+	}
 	QString arg = calldata_string(cd, "property");
 	if (arg == "wb_mode")
 		calldata_set_int(cd, "wb_mode", obs_data_get_int(settings, "wb_mode"));
@@ -789,6 +793,10 @@ void PTZVisca::get(calldata_t *cd) const
 
 void PTZVisca::set(calldata_t *cd)
 {
+	if (QThread::currentThread() != thread()) {
+		ptz_log(LOG_ERROR, "PTZVisca::set(calldata) called from non-GUI thread; ignored");
+		return;
+	}
 	bool power_on;
 	if (calldata_get_bool(cd, "power_on", &power_on))
 		send(VISCA_CAM_Power, {power_on});

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -248,9 +248,9 @@ PTZJoyButtonMapper::PTZJoyButtonMapper(QWidget *parent, size_t _button) : QPushB
 			data_t &d = *static_cast<data_t *>(data);
 			if (obs_hotkey_get_registerer_type(key) != OBS_HOTKEY_REGISTERER_FRONTEND)
 				return true; /* todo: extra logic needed for other hotkey registerers */
-			auto a = get<0>(d)->addAction(obs_hotkey_get_description(key));
+			auto a = std::get<0>(d)->addAction(obs_hotkey_get_description(key));
 			a->setData(obs_hotkey_get_name(key));
-			connect(a, &QAction::triggered, get<1>(d), &PTZJoyButtonMapper::on_menuAction);
+			connect(a, &QAction::triggered, std::get<1>(d), &PTZJoyButtonMapper::on_menuAction);
 			return true;
 		},
 		&data);
@@ -282,8 +282,8 @@ void PTZJoyButtonMapper::on_hotkeyChanged(size_t _button, QString hotkey_name)
 	obs_enum_hotkeys(
 		[](void *data, obs_hotkey_id, obs_hotkey_t *key) {
 			data_t &d = *static_cast<data_t *>(data);
-			if (get<0>(d) == obs_hotkey_get_name(key)) {
-				get<1>(d)->setText(obs_hotkey_get_description(key));
+			if (std::get<0>(d) == obs_hotkey_get_name(key)) {
+				std::get<1>(d)->setText(obs_hotkey_get_description(key));
 				return false;
 			}
 			return true;


### PR DESCRIPTION
Switching to the prochandler API broke the action source because the proc handler lambdas were ignoring all calls from threads other than the GUI thread. This was done because the calldata structure usually lives on the callers stack, and if a call was queued on the correct thread, e.g. by calling QMetaObject::invokeMethod(), then the calldata would be gone by the time the method ran. However, the action source triggers don't come from the UI thread.

To fix this, rework the proc handlers to extract the calldata arguments in the callers thread, and then use invokeMethod() to call the device method, using the default Qt::AutoConnection mode so that calls from the GUI thread are direct, but calls from other threads get queued. For most methods this works fine because the calls are commands to the device.

The one exception is the ::get() method which needs to return data to the caller. This is the one proc handler method that still needs to be called by the GUI thread, and it gets ignored if it is not. This perhaps could be fixed by using a BlockingQueued connection, but it is unclear if it is needed and that change can be done in another patch.