### PR TITLE
ptz-controls: auto-save config + clamp preset_max

### DIFF
--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -193,6 +193,27 @@ PTZControls::PTZControls(QWidget *parent) : QFrame(parent), ui(new Ui::PTZContro
 
 	LoadConfig();
 
+	/* Periodically persist the configuration so that user changes are not
+	 * lost if OBS terminates abnormally. SaveConfig() is otherwise only
+	 * called on a clean OBS_FRONTEND_EVENT_EXIT. The timer only writes to
+	 * disk when something actually changed (config_dirty). */
+	config_dirty = false; /* loading must not count as a change */
+	autosave_timer.setInterval(30000);
+	connect(&autosave_timer, &QTimer::timeout, this, [this]() {
+		if (config_dirty) {
+			SaveConfig();
+			config_dirty = false;
+		}
+	});
+	autosave_timer.start();
+
+	/* Flag the configuration dirty from a single, central place by
+	 * reacting to the existing change signals, rather than sprinkling
+	 * markConfigDirty() calls throughout every setter. */
+	connect(this, &PTZControls::autoselectEnabledChanged, this, &PTZControls::markConfigDirty);
+	connect(this, &PTZControls::liveMoveLockEnabledChanged, this, &PTZControls::markConfigDirty);
+	connect(this, &PTZControls::speedRampEnabledChanged, this, &PTZControls::markConfigDirty);
+
 	/* Install an event filter to keep buttons square */
 	auto filter = new squareResizeFilter(this);
 	ui->movementControlsWidget->installEventFilter(filter);
@@ -499,6 +520,11 @@ void PTZControls::copyActionsDynamicProperties()
 /*
  * Save/Load configuration methods
  */
+void PTZControls::markConfigDirty()
+{
+	config_dirty = true;
+}
+
 void PTZControls::SaveConfig()
 {
 	char *file = obs_module_config_path("config.json");
@@ -948,6 +974,7 @@ void PTZControls::currentChanged(QModelIndex current, QModelIndex previous)
 			connect(selectionModel, &QItemSelectionModel::currentChanged, this,
 				&PTZControls::presetUpdateActions);
 		connect(ptz, &PTZDevice::settingsChanged, this, &PTZControls::settingsChanged);
+		connect(ptz, &PTZDevice::settingsChanged, this, &PTZControls::markConfigDirty);
 		settingsChanged();
 	}
 

--- a/src/ptz-controls.hpp
+++ b/src/ptz-controls.hpp
@@ -58,6 +58,8 @@ private:
 	double focus_speed = 0.0;
 	double focus_accel = 0.0;
 	QTimer accel_timer;
+	QTimer autosave_timer;
+	bool config_dirty = false;
 
 	bool pantiltingFlag = false;
 	bool zoomingFlag = false;
@@ -66,6 +68,7 @@ private:
 	void copyActionsDynamicProperties();
 	void SaveConfig();
 	void LoadConfig();
+	void markConfigDirty();
 
 	void setZoom(double speed);
 	void setFocus(double speed);

--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <obs.hpp>
+#include <algorithm>
 #include "ptz-device.hpp"
 #include "ptz-list-model.hpp"
 #include "ptz-preset-model.hpp"
@@ -258,7 +259,10 @@ void PTZDevice::update(OBSData config)
 	getDefaults(config);
 
 	/* Update the list of preset names */
-	m_presetsModel.setMaxPresets((size_t)obs_data_get_int(config, "preset_max"));
+	/* Clamp to the same range enforced by the properties slider; a corrupt
+	 * or hand-edited config must not yield an absurd preset count. */
+	long long preset_max = std::clamp<long long>(obs_data_get_int(config, "preset_max"), 1, 128);
+	m_presetsModel.setMaxPresets((size_t)preset_max);
 	OBSDataArrayAutoRelease preset_array = obs_data_get_array(config, "presets");
 	m_presetsModel.loadPresets(preset_array.Get());
 


### PR DESCRIPTION
Reworked from #302 per your review.

* ptz-controls: periodic auto-save. The dirty flag is now raised from a single central slot wired to the existing change signals, instead of scattering markDirty() through every setter. Rationale is in the commit message rather than a separate .md file.
* ptz-device: clamp preset_max to the 1..128 slider range (your "Use clamp()?" suggestion), guarding against corrupt configs.

Both commits are clang-format clean and carry a DCO Signed-off-by line. The crash/threading change is intentionally left out since you reverted that approach, and the custom config backup is dropped as redundant with the existing obs_data_*_safe("bak") mechanism.