### PR TITLE
ptz-device: Match the camera source name verbatim

### DIFF
--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -82,8 +82,15 @@ PTZDevice::~PTZDevice()
 
 void PTZDevice::setObjectName(QString name)
 {
-	name = name.simplified();
-	if (name == "") {
+	/* The device name must exactly match the associated OBS source name,
+	 * because the source is resolved via obs_get_source_by_name(). OBS
+	 * permits source names with leading, trailing or repeated whitespace,
+	 * so normalising the name here (previously QString::simplified())
+	 * silently broke that link and PTZ commands no longer reached the
+	 * camera. Keep the name verbatim and only use simplified() to detect an
+	 * effectively empty name.
+	 */
+	if (name.simplified().isEmpty()) {
 		if (objectName().startsWith(obs_module_text("PTZ.Device.DefaultName")))
 			return;
 		name = obs_module_text("PTZ.Device.DefaultName");


### PR DESCRIPTION
Fixes #318.

A PTZ device is linked to its OBS source by name, resolved with obs_get_source_by_name(objectName()). setObjectName() first ran the name through QString::simplified(), which strips leading/trailing whitespace and collapses repeated spaces. OBS itself allows source names containing such whitespace, so for a source named " Camera" the stored device name became "Camera" and the lookup returned nothing - PTZ commands then silently never reached the camera. The same mismatch also broke scene-based autoselect.

The name is now kept verbatim so it matches the OBS source exactly; simplified() is only used to detect an effectively empty name.

Built cleanly on Ubuntu, macOS and Windows via CI.