### PR TITLE
settings: Allow clearing a joystick button mapping

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -240,7 +240,13 @@ PTZJoyButtonMapper::PTZJoyButtonMapper(QWidget *parent, size_t _button) : QPushB
 {
 	setCheckable(true);
 	auto m = new QMenu;
-	m->addAction(obs_module_text("None"));
+	/* The "None" entry must be wired up like the hotkey entries below;
+	 * without a triggered connection clicking it did nothing, so a button
+	 * mapping could never be cleared (#269). The action carries no data, so
+	 * on_menuAction() passes an empty hotkey name, which
+	 * setJoystickButtonHotkey() interprets as "remove the mapping". */
+	auto none_action = m->addAction(obs_module_text("None"));
+	connect(none_action, &QAction::triggered, this, &PTZJoyButtonMapper::on_menuAction);
 	auto data = std::make_tuple(m, this);
 	using data_t = decltype(data);
 	obs_enum_hotkeys(


### PR DESCRIPTION
Fixes #269.

In the joystick button mapping menu, every hotkey entry is wired to on_menuAction(), but the "None" entry was added without connecting its triggered() signal - so selecting "None" did nothing and a button could never be set back to unmapped.

The "None" action is now connected like the others. It carries no data, so on_menuAction() forwards an empty hotkey name, which setJoystickButtonHotkey() already treats as "remove the mapping".

Built cleanly on Ubuntu, macOS and Windows via CI.