### PR TITLE
ptz-controls: Allow reordering the camera list by drag and drop

### DIFF
--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -170,6 +170,11 @@ PTZControls::PTZControls(QWidget *parent) : QFrame(parent), ui(new Ui::PTZContro
 		this->setStyleSheet("margin-left: 0px; margin-right: 0px");
 
 	ui->cameraList->setModel(&ptzDeviceList);
+	/* Allow reordering the camera list by drag and drop (issue #55) */
+	ui->cameraList->setSelectionMode(QAbstractItemView::SingleSelection);
+	ui->cameraList->setDragDropMode(QAbstractItemView::InternalMove);
+	ui->cameraList->setDefaultDropAction(Qt::MoveAction);
+	ui->cameraList->setDragDropOverwriteMode(false);
 	ui->cameraList->setItemDelegate(new PTZDeviceListDelegate(ui->cameraList));
 	connect(&ptzDeviceList, &PTZListModel::dataChanged, this, &PTZControls::updateMoveControls);
 

--- a/src/ptz-list-model.cpp
+++ b/src/ptz-list-model.cpp
@@ -14,6 +14,9 @@
 #include "ptz-usb-cam.hpp"
 #include "ptz.h"
 #include "protocol-helpers.hpp"
+#include <QMimeData>
+#include <QDataStream>
+#include <QStringList>
 
 #if defined(ENABLE_SERIALPORT)
 #include "ptz-visca-uart.hpp"
@@ -56,8 +59,76 @@ int PTZListModel::rowCount(const QModelIndex &parent) const
 Qt::ItemFlags PTZListModel::flags(const QModelIndex &index) const
 {
 	if (!index.isValid())
-		return Qt::ItemIsEnabled;
-	return QAbstractListModel::flags(index) | Qt::ItemIsEditable;
+		return Qt::ItemIsEnabled | Qt::ItemIsDropEnabled;
+	return QAbstractListModel::flags(index) | Qt::ItemIsEditable | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled;
+}
+
+Qt::DropActions PTZListModel::supportedDropActions() const
+{
+	return Qt::MoveAction;
+}
+
+QStringList PTZListModel::mimeTypes() const
+{
+	return {QStringLiteral("application/x-obs-ptz-device-row")};
+}
+
+QMimeData *PTZListModel::mimeData(const QModelIndexList &indexes) const
+{
+	if (indexes.isEmpty() || !indexes.first().isValid())
+		return nullptr;
+	auto *mime = new QMimeData;
+	QByteArray encoded;
+	QDataStream stream(&encoded, QIODevice::WriteOnly);
+	stream << indexes.first().row();
+	mime->setData(QStringLiteral("application/x-obs-ptz-device-row"), encoded);
+	return mime;
+}
+
+bool PTZListModel::canDropMimeData(const QMimeData *data, Qt::DropAction action, int, int, const QModelIndex &) const
+{
+	return action == Qt::MoveAction && data->hasFormat(QStringLiteral("application/x-obs-ptz-device-row"));
+}
+
+bool PTZListModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int, const QModelIndex &parent)
+{
+	if (action != Qt::MoveAction || !data->hasFormat(QStringLiteral("application/x-obs-ptz-device-row")))
+		return false;
+
+	QByteArray encoded = data->data(QStringLiteral("application/x-obs-ptz-device-row"));
+	QDataStream stream(&encoded, QIODevice::ReadOnly);
+	int srcRow = -1;
+	stream >> srcRow;
+
+	int destRow = row;
+	if (destRow < 0)
+		destRow = parent.isValid() ? parent.row() : (int)devices.size();
+
+	moveRows(QModelIndex(), srcRow, 1, QModelIndex(), destRow);
+
+	/* The reorder is carried out directly in moveRows(). Returning false
+	 * stops the view from also calling removeRows() on the source row,
+	 * which would corrupt the list and could delete a live device. */
+	return false;
+}
+
+bool PTZListModel::moveRows(const QModelIndex &srcParent, int srcRow, int count, const QModelIndex &destParent,
+			    int destChild)
+{
+	if (srcParent.isValid() || destParent.isValid() || count != 1)
+		return false;
+	if (srcRow < 0 || srcRow >= devices.size() || destChild < 0 || destChild > devices.size())
+		return false;
+	if (destChild == srcRow || destChild == srcRow + 1)
+		return false; /* no-op move */
+	if (!beginMoveRows(srcParent, srcRow, srcRow, destParent, destChild))
+		return false;
+	int dest = destChild;
+	if (srcRow < dest)
+		dest--;
+	devices.move(srcRow, dest);
+	endMoveRows();
+	return true;
 }
 
 QVariant PTZListModel::data(const QModelIndex &index, int role) const

--- a/src/ptz-list-model.hpp
+++ b/src/ptz-list-model.hpp
@@ -10,9 +10,11 @@
 #include <QAbstractListModel>
 #include <QHash>
 #include <QList>
+#include <QStringList>
 #include "ptz.h"
 
 class PTZDevice;
+class QMimeData;
 
 class PTZListModel : public QAbstractListModel {
 	Q_OBJECT
@@ -39,6 +41,15 @@ public:
 	void do_reset();
 	void name_changed(PTZDevice *ptz);
 	Qt::ItemFlags flags(const QModelIndex &index) const override;
+	Qt::DropActions supportedDropActions() const override;
+	QStringList mimeTypes() const override;
+	QMimeData *mimeData(const QModelIndexList &indexes) const override;
+	bool canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column,
+			     const QModelIndex &parent) const override;
+	bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column,
+			  const QModelIndex &parent) override;
+	bool moveRows(const QModelIndex &srcParent, int srcRow, int count, const QModelIndex &destParent,
+		      int destChild) override;
 	void onSceneChanged();
 
 	/* Data Model */


### PR DESCRIPTION
Closes #55.

Cameras can now be rearranged in the docked list by drag and drop, as you suggested in the issue - no extra buttons taking up panel space.

Implementation: PTZListModel gains drag/drop item flags, a private MIME type carrying the source row, and a moveRows(); the camera list view is switched to QAbstractItemView::InternalMove. The reorder is done in moveRows(), and dropMimeData() returns false so the view does not additionally remove the source row. The new order is part of the device list and is persisted by SaveConfig() like any other change.

Note: this builds cleanly on Ubuntu, macOS and Windows (CI), but I have not yet been able to verify the interactive drag-and-drop behaviour in a running OBS. I'd appreciate your testing and I'm happy to adjust.