### PR TITLE
ptz-controls: Show the controlled camera name above the presets

### DIFF
--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -940,6 +940,9 @@ void PTZControls::currentChanged(QModelIndex current, QModelIndex previous)
 	focus_speed = focus_accel = 0.0;
 
 	ptz = ptzDeviceList.getDevice(current);
+	/* Show which camera is currently being controlled above the presets
+	 * (issue #123); particularly useful with auto-select. */
+	ui->cameraLabel->setText(ptz ? ptz->objectName() : QString());
 	if (ptz) {
 		ui->presetListView->setModel(ptz->presetModel());
 		presetUpdateActions();

--- a/src/ptz-controls.ui
+++ b/src/ptz-controls.ui
@@ -432,13 +432,44 @@
        </property>
       </widget>
      </widget>
-     <widget class="CircularListView" name="presetListView">
-      <property name="contextMenuPolicy">
-       <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
-      </property>
-      <property name="editTriggers">
-       <set>QAbstractItemView::EditTrigger::EditKeyPressed</set>
-      </property>
+     <widget class="QWidget" name="presetPanel" native="true">
+      <layout class="QVBoxLayout" name="presetPanelLayout">
+       <property name="spacing">
+        <number>2</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="cameraLabel">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="CircularListView" name="presetListView">
+         <property name="contextMenuPolicy">
+          <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::EditTrigger::EditKeyPressed</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </widget>
    </item>


### PR DESCRIPTION
Closes #123.

When the active camera is switched automatically (auto-select on preview/program), or just after some time has passed, it is easy to lose track of which camera the controls and presets apply to. This adds a label above the preset list showing the name of the currently selected camera (cleared when none is selected). The preset list is wrapped in a small container widget so the label sits directly above it inside the existing splitter pane.

Note: this builds cleanly on Ubuntu, macOS and Windows (CI), but I have not yet been able to verify the visual layout/placement in a running OBS - I'd appreciate your check. The label updates on camera selection; refreshing it on rename-while-selected could be a small follow-up if you'd like.