### PR TITLE
buildspec: Update dependencies for OBS Studio 32.2.1 / Qt 6.11.1

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -73,7 +73,7 @@ jobs:
 
   macos-build:
     name: Build for macOS 🍏
-    runs-on: macos-15
+    runs-on: macos-26
     needs: check-event
     defaults:
       run:
@@ -90,8 +90,8 @@ jobs:
           : Set Up Environment 🔧
           if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-          print '::group::Enable Xcode 16.1'
-          sudo xcode-select --switch /Applications/Xcode_16.1.0.app/Contents/Developer
+          print '::group::Enable Xcode 26.5'
+          sudo xcode-select --switch /Applications/Xcode_26.5.app/Contents/Developer
           print '::endgroup::'
 
           print '::group::Clean Homebrew Environment'

--- a/buildspec.json
+++ b/buildspec.json
@@ -1,42 +1,42 @@
 {
     "dependencies": {
         "obs-studio": {
-            "version": "31.1.1",
+            "version": "32.2.1",
             "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
             "label": "OBS sources",
             "hashes": {
-                "macos": "39751f067bacc13d44b116c5138491b5f1391f91516d3d590d874edd21292291",
-                "windows-x64": "2c8427c10b55ac6d68008df2e9a3e82f4647aaad18f105e30d4713c2de678ccf"
+                "macos": "db034bc3d2c137ec7f1809cbef4fc90c8948652b90a860078410482457d8a574",
+                "windows-x64": "0cc1bd46a3d60c8f4317b38c27414fc0472e04609f4e67ad2142ed1598ef5462"
             }
         },
         "prebuilt": {
-            "version": "2025-07-11",
+            "version": "2026-07-15",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built obs-deps",
             "hashes": {
-                "macos": "495687e63383d1a287684b6e2e9bfe246bb8f156fe265926afb1a325af1edd2a",
-                "windows-x64": "c8c642c1070dc31ce9a0f1e4cef5bb992f4bff4882255788b5da12129e85caa7"
+                "macos": "4ecb4c598dfa853168df6c2a0c4e0ffec8495a81fbd1ba051ef88ecd5e0f7e53",
+                "windows-x64": "6f90e9598fa10cff5ad23cdcfae49b87868c07bf896b02cd464582b4ce2f2ba9"
             }
         },
         "qt6": {
-            "version": "2025-07-11",
+            "version": "2026-07-15",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built Qt6",
             "hashes": {
-                "macos": "d3f5f04b6ea486e032530bdf0187cbda9a54e0a49621a4c8ba984c5023998867",
-                "windows-x64": "0e76bf0555dd5382838850b748d3dcfab44a1e1058441309ab54e1a65b156d0a"
+                "macos": "d4b8058612a7067e44b2205fe7925ee24e9ec6b15ac8c29d3e6230c70030b102",
+                "windows-x64": "7c7f985711d80467bdc1795b6592275a27d5b0e5a2c7a61db1f2c1d08d6a5579"
             },
             "debugSymbols": {
-                "windows-x64": "11b7be92cf66a273299b8f3515c07a5cfb61614b59a4e67f7fc5ecba5e2bdf21"
+                "windows-x64": "471d0b2191c424a520a51d064f3741084f117e1ff6ee5af1d16aabcdbacc6659"
             }
         },
         "qtserialport": {
-            "version": "6.8.3",
-            "baseUrl": "https://download.qt.io/archive/qt/6.8/6.8.3/submodules",
+            "version": "6.11.1",
+            "baseUrl": "https://download.qt.io/archive/qt/6.11/6.11.1/submodules",
             "label": "Qt6SerialPort",
             "hashes": {
-                "macos": "c164a0392dc7cab3d072fa8fdcacc8fc4f3e685234b021b3128020719cdf5fa5",
-                "windows-x64": "d708acbf95cf7032e8c5549e680ee04b2a44f0510c1abf9405b6596b96230274"
+                "macos": "9af31a898ffd9a7e4faf6fed845d29e783c716885789055cbe319f3e072d3974",
+                "windows-x64": "c4eb4ff1e3ac1ca39630b4614028b225af1fc1cb9504389efdd3b0a7833a2c1f"
             }
         },
         "sdl": {
@@ -56,7 +56,7 @@
     },
     "name": "obs-ptz",
     "displayName": "PTZ Camera Control for OBS",
-    "version": "0.18.2",
+    "version": "0.18.3",
     "author": "Grant Likely",
     "website": "https://obsproject.com/forum/resources/ptz-controls.1284",
     "email": "grant.likely@secretlab.ca"

--- a/shared/properties-view/CMakeLists.txt
+++ b/shared/properties-view/CMakeLists.txt
@@ -44,6 +44,17 @@ target_sources(
 )
 target_include_directories(properties-view INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 
+# properties-view.cpp mirrors OBS's own widget and still calls the
+# obs_data_*_autoselect_* API, which OBS 32 marks OBS_DEPRECATED. The calls
+# remain functional; silence only the deprecation diagnostic so the plugin
+# template's warnings-as-errors (/WX, -Werror) does not fail the build.
+target_compile_options(
+  properties-view
+  INTERFACE
+    $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/wd4996>
+    $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:-Wno-deprecated-declarations>
+)
+
 target_link_libraries(
   properties-view
   INTERFACE

--- a/src/ptz-action-source.c
+++ b/src/ptz-action-source.c
@@ -226,7 +226,6 @@ static bool ptz_action_source_test_clicked_cb(obs_properties_t *props, obs_prope
 static obs_properties_t *ptz_action_source_get_properties(void *data)
 {
 	obs_properties_t *props = obs_properties_create();
-	UNUSED_PARAMETER(data);
 
 	/* List the possible trigger events */
 	obs_property_t *prop =
@@ -258,7 +257,7 @@ static obs_properties_t *ptz_action_source_get_properties(void *data)
 	obs_properties_add_list(props, "preset_id", "Preset", OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
 	obs_properties_add_float_slider(props, "pan_speed", "Pan Speed", -1.0, 1.0, 0.01);
 	obs_properties_add_float_slider(props, "tilt_speed", "Tilt Speed", -1.0, 1.0, 0.01);
-	obs_properties_add_button(props, "run_action", "Test Action", ptz_action_source_test_clicked_cb);
+	obs_properties_add_button2(props, "run_action", "Test Action", ptz_action_source_test_clicked_cb, data);
 
 	return props;
 }


### PR DESCRIPTION
Fixes #331: the plugin fails to load on OBS 32.2.1 with a Qt symbol mismatch (QIODevicePrivate) because OBS 32.2.1 ships Qt 6.11.1 while the plugin still bundled QtSerialPort 6.8.3.

## Changes

**buildspec.json** – update build dependencies to match OBS 32.2.1:
- obs-studio sources: 31.1.1 -> 32.2.1
- prebuilt obs-deps and qt6: 2025-07-11 -> 2026-07-15
- qtserialport: 6.8.3 -> 6.11.1 (matches OBS 32.2.1 Qt version)
- bump plugin version: 0.18.2 -> 0.18.3

**Source/build compat fixes for the OBS 32 API** (surfaced when building against 32.2.1 with the template's warnings-as-errors):
- `src/ptz-action-source.c`: use `obs_properties_add_button2()` instead of the now-deprecated `obs_properties_add_button()`.
- `shared/properties-view/CMakeLists.txt`: silence only the C4996 / `-Wdeprecated-declarations` diagnostic for the vendored `properties-view.cpp`, which still calls the (functional but `OBS_DEPRECATED`) `obs_data_*_autoselect_*` API. The calls themselves are left unchanged so behaviour matches upstream OBS.

## Testing

- Local build on Windows (x64, VS 2022, `ci=1` / `Build-Windows.ps1`) completes with **0 warnings, 0 errors** and produces `obs-ptz.dll` + `Qt6SerialPort.dll` (6.11.1).
- Installed into OBS Studio 32.2.1 (x64): the plugin now **loads without the previous "module not loaded" error** from #331 and the PTZ Controls dock is available.
- CI on this PR additionally validates the build across platforms.

## Notes

- The obs-studio, prebuilt obs-deps and qt6 hashes were verified against the official OBS Studio 32.2.1 `CMakePresets.json` and the obs-deps 2026-07-15 release.
- The QtSerialPort 6.11.1 source hashes are not covered by an upstream OBS checksum file; they were confirmed working by the successful local build and are also exercised by CI.