### PR TITLE
ci: repair the clang-format and gersemi checks

### DIFF
--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -36,6 +36,7 @@ runs:
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
         echo "/home/linuxbrew/.linuxbrew/opt/clang-format@19/bin" >> $GITHUB_PATH
+        brew update
         brew install --quiet zsh
         echo ::endgroup::
 
@@ -51,6 +52,8 @@ runs:
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
         print ::group::Install clang-format-19
+        brew update
+        brew trust obsproject/tools
         brew install --quiet obsproject/tools/clang-format@19
         print ::endgroup::
 

--- a/.github/actions/run-gersemi/action.yaml
+++ b/.github/actions/run-gersemi/action.yaml
@@ -35,6 +35,7 @@ runs:
         echo ::group::Install Dependencies
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+        brew update
         brew install --quiet zsh
         echo ::endgroup::
 
@@ -50,6 +51,8 @@ runs:
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
         print ::group::Install gersemi
+        brew update
+        brew trust obsproject/tools
         brew install --quiet obsproject/tools/gersemi
         print ::endgroup::
 


### PR DESCRIPTION
Both format checks currently fail on every PR that touches C/C++ or CMake files, because Homebrew no longer runs formula install steps from an untrusted third party tap:

    Skipping obsproject/tools because it is not trusted. Run `brew trust obsproject/tools`
    Error: unknown install step: run

The failure happens in the install step, not in the formatting itself, so it is unrelated to the contents of the PR being checked (see the red clang-format / gersemi checks on #333).

Fix: refresh the Homebrew metadata and trust the `obsproject/tools` tap before installing the formatters. This mirrors the change obs-studio applied upstream in `.github/actions/run-clang-format` and `.github/actions/run-gersemi`.

The pinned tool versions are deliberately left untouched (clang-format 19.1.1 as required by `build-aux/run-clang-format`, and the tap's default `gersemi` formula), so no reformatting of existing files is expected.