### PR TITLE
settings: Widen the joystick deadzone slider to the supported range

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -196,7 +196,7 @@ void PTZSettings::joystickSetup()
 	ui->joystickNamesListView->setModel(&m_joystickNamesModel);
 	ui->joystickGroupBox->setChecked(controls->joystickEnabled());
 	ui->joystickSpeedSlider->setDoubleConstraints(0.25, 1.75, 0.05, controls->joystickSpeed());
-	ui->joystickDeadzoneSlider->setDoubleConstraints(0.01, 0.15, 0.01, controls->joystickDeadzone());
+	ui->joystickDeadzoneSlider->setDoubleConstraints(0.01, 0.5, 0.01, controls->joystickDeadzone());
 
 	connect(joysticks, &QJoysticks::countChanged, this, &PTZSettings::joystickUpdate);
 	connect(joysticks, &QJoysticks::axisEvent, this, &PTZSettings::joystickAxisEvent);


### PR DESCRIPTION
Fixes #329.

`PTZControls::setJoystickDeadzone()` already clamps to 0.0 - 0.5, but the settings slider was constrained to a maximum of 0.15, so the upper half of the supported range was unreachable from the UI.

The narrow slider range also silently overwrote a larger value set by editing `config.json` by hand, which is what the reporter of #329 observed. `DoubleSlider` maps the double onto an integer range, and `int(total / minStep)` truncates: `int((0.15 - 0.01) / 0.01)` is 13, not 14, because the division yields 13.999999999999998. Opening the settings page therefore called `setValue(49)` on a slider whose maximum is 13, QSlider clamped it, and the resulting `doubleValChanged()` fed 0.14 straight back into `setJoystickDeadzone()`. That also explains the reporter's "previous max of .14" — the effective maximum really was 0.14, not the 0.15 in the source.

## Testing

Built from source and run against OBS Studio 32.2.1 (Qt 6.11.1) on Windows. Both builds are this branch and current `main`, so the only difference is this one line. The plugin logs its version on load, which I checked before each measurement.

| Build | What I did | `joystick_deadzone` in `config.json` afterwards |
|---|---|---|
| this branch, `v0.18.3-rc1-65-g7da2f7d` | dragged the slider to its maximum, closed OBS | `0.5` |
| `main`, `v0.18.3-rc1-64-g1b9fda2` | only opened the PTZ settings page, closed OBS | `0.14` |

The second row is the counter-proof and the reported bug at the same time: I did not touch the slider. The stored `0.5` was overwritten with `0.14` merely by opening the settings page, and persisted on exit.

One limitation: I have no controller with a drifting stick here, so what I verified is the range and the persistence, not that a deadzone of 0.5 cures a particular device.