### PR TITLE
ptz-controls: Show the controlled camera name above the presets

### DIFF
--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -186,6 +186,7 @@ PTZControls::PTZControls(QWidget *parent) : QFrame(parent), ui(new Ui::PTZContro
 	ui->cameraList->setModel(&ptzDeviceList);
 	ui->cameraList->setItemDelegate(new PTZDeviceListDelegate(ui->cameraList));
 	connect(&ptzDeviceList, &PTZListModel::dataChanged, this, &PTZControls::settingsChanged);
+	connect(&ptzDeviceList, &PTZListModel::dataChanged, this, &PTZControls::updateCameraLabel);
 
 	copyActionsDynamicProperties();
 
@@ -978,6 +979,23 @@ void PTZControls::updateMoveControls()
 	calldata_free(&cd);
 }
 
+/* Show which camera is currently being controlled above the presets. With
+ * auto-select enabled the selection can change without the user touching
+ * anything, and the preset list on its own gives no clue which camera it
+ * belongs to. Driven by the selection and by PTZListModel::dataChanged, so
+ * that renaming the selected camera updates the label rather than leaving
+ * the old name on screen. */
+void PTZControls::updateCameraLabel()
+{
+	auto ptz = ptzDeviceList.getDevice(ui->cameraList->currentIndex());
+	const QString name = ptz ? ptz->objectName() : QString();
+
+	ui->cameraLabel->setText(name);
+	/* Hide the header while nothing is selected; an empty label would
+	 * otherwise still claim its margin at the top of the dock. */
+	ui->cameraLabel->setVisible(!name.isEmpty());
+}
+
 void PTZControls::currentChanged(QModelIndex current, QModelIndex previous)
 {
 	accel_timer.stop();
@@ -992,6 +1010,7 @@ void PTZControls::currentChanged(QModelIndex current, QModelIndex previous)
 	focus_speed = focus_accel = 0.0;
 
 	ui->presetListView->setRootIndex(current);
+	updateCameraLabel();
 	updateMoveControls();
 }
 

--- a/src/ptz-controls.hpp
+++ b/src/ptz-controls.hpp
@@ -90,6 +90,7 @@ public slots:
 	void autoselectDevice(OBSSource scene);
 private slots:
 	void updateMoveControls();
+	void updateCameraLabel();
 	void onHomeButtonContextMenu(const QPoint &pos);
 	void setPanTilt(double pan, double tilt, double pan_accel = 0, double tilt_accel = 0);
 	void keypressPanTilt(double pan, double tilt);

--- a/src/ptz-controls.ui
+++ b/src/ptz-controls.ui
@@ -482,6 +482,24 @@
         <number>0</number>
        </property>
        <item>
+        <widget class="QLabel" name="cameraLabel">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+         <property name="margin">
+          <number>4</number>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="CircularListView" name="presetListView">
          <property name="contextMenuPolicy">
           <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>


### PR DESCRIPTION
Replaces #327, which GitHub would not let @glikely reopen. Same branch, but the commit has moved on since that pull request was closed — #327 still shows `ab10b6b` from June, this is `87058f3`.

Fixes #123.

The preset list gets a label above it showing the camera that is currently being controlled. `presetListView` moves into a `QVBoxLayout` with a `QLabel` on top.

Compared to the version in #327 the label is no longer only set in `currentChanged()`. It is also driven by `PTZListModel::dataChanged`, so renaming the camera that is already selected updates the label instead of leaving the old name standing. That was the gap I flagged myself when I first opened #327.

## Testing

Built from source and run against OBS Studio 32.2.1 (Qt 6.11.1) on Windows, with two devices configured — a UVC webcam and a VISCA-over-IP entry. Version strings from the OBS log:

* this branch: `v0.18.3-rc1-65-gb0edebd`
* `main` for comparison: `v0.18.3-rc1-64-g1b9fda2`

What I verified:

* The label sits above the preset list and names the camera being controlled.
* Selecting the other device switches the label with it.
* **Renaming the source of the selected camera updates the label immediately.**
* Narrowing the dock: the label lives inside the preset column of the existing splitter, so dragging the splitter collapses that column exactly as it did before this patch. The label does not raise the column's minimum width.
* Counter-proof on `main`: no label at all, the space above the preset list is empty.

Two things I could not check, so they are not silently claimed:

* **Light theme.** This OBS install only ships Yami with the Default style, so I have only seen the label on a dark background. It uses no explicit colour and inherits the palette, but I have not seen it myself on a light theme.
* **Autoselect on scene change.** One scene with one camera source here; switching by hand works, the autoselect path is untested.

The branch sits on `c20be21`, one commit behind current `main`, and merges cleanly — happy to rebase onto `9315a82` if you would rather have it linear.