### PR TITLE
ptz-controls: Skip preset recall when nothing is selected

### DIFF
--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -337,7 +337,9 @@ PTZControls::PTZControls(QWidget *parent) : QFrame(parent), ui(new Ui::PTZContro
 		[](void *ptz_data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
 			if (ptz_data && pressed) {
 				auto ctrls = static_cast<PTZControls *>(ptz_data);
-				ctrls->on_presetListView_activated(ctrls->ui->presetListView->currentIndex());
+				auto index = ctrls->ui->presetListView->currentIndex();
+				if (index.isValid())
+					ctrls->on_presetListView_activated(index);
 			}
 		},
 		this);


### PR DESCRIPTION
Follow-up to #337, as offered there. Two lines.

`PTZ.PresetRecallSelected` hands `presetListView->currentIndex()` straight to `on_presetListView_activated()`. With an empty preset list, or before anything has been selected, that index is invalid and `presetIndexToId()` returns -1.

Most backends shrug that off — `PTZPelco::memory_recall()` rejects negative ids, `PTZOnvif::memory_recall()` finds no token and returns, `PTZUSBCam::memory_recall()` finds no stored preset. VISCA does not check. `visca_u7` keeps the low seven bits, so -1 is encoded as `0x7f` and the camera is asked to recall preset 127:

```
81 01 04 3f 02 7f ff
```

I worked that out against `int_field::encode()` rather than guessing: with `mask = 0x7f` the loop copies seven bits out of the value, and every one of them is set for -1.

This also restores what the commit message of c20be21 already promises — *"Recalling with nothing selected is a no-op rather than an invalid preset id"* — which was true of the original version but got lost when the helper was replaced.

It is in v0.19.0-rc1, hence sending it now rather than sitting on it.

Not separately tested on hardware: I have no VISCA camera here, so I have not watched the packet leave. The reasoning is from the code, and the change itself only adds a validity check on a path that otherwise passes -1 downstream.