### PR TITLE
Build .deb packages for multiple Ubuntu releases

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -179,7 +179,7 @@ jobs:
     name: Build for Ubuntu 🐧
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-26.04, ubuntu-24.04, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     needs: check-event
     defaults:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -74,7 +74,9 @@ jobs:
           variants=(
             'windows-x64;zip|exe'
             'macos-universal;tar.xz|pkg'
+            'ubuntu-26.04-x86_64;tar.xz|deb|ddeb'
             'ubuntu-24.04-x86_64;tar.xz|deb|ddeb'
+            'ubuntu-22.04-x86_64;tar.xz|deb|ddeb'
             'sources;tar.xz'
           )
 

--- a/cmake/linux/defaults.cmake
+++ b/cmake/linux/defaults.cmake
@@ -16,6 +16,28 @@ set(CPACK_PACKAGE_NAME "${CMAKE_PROJECT_NAME}")
 set(CPACK_PACKAGE_VERSION "${CMAKE_PROJECT_VERSION}")
 set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_C_LIBRARY_ARCHITECTURE}")
 
+# Debian package dependencies (e.g. Qt6's "t64" library renaming) are tied to
+# the exact distro release they're built on, so tag the package file name
+# with the build machine's distro/version to avoid two incompatible builds
+# from colliding under the same file name.
+if(EXISTS "/etc/os-release")
+  file(STRINGS "/etc/os-release" _ptz_os_release_lines)
+  foreach(_ptz_os_release_line IN LISTS _ptz_os_release_lines)
+    if(_ptz_os_release_line MATCHES "^ID=\"?([^\"]*)\"?$")
+      set(_ptz_os_id "${CMAKE_MATCH_1}")
+    elseif(_ptz_os_release_line MATCHES "^VERSION_ID=\"?([^\"]*)\"?$")
+      set(_ptz_os_version_id "${CMAKE_MATCH_1}")
+    endif()
+  endforeach()
+  if(_ptz_os_id AND _ptz_os_version_id)
+    string(APPEND CPACK_PACKAGE_FILE_NAME "-${_ptz_os_id}${_ptz_os_version_id}")
+  endif()
+  unset(_ptz_os_release_lines)
+  unset(_ptz_os_release_line)
+  unset(_ptz_os_id)
+  unset(_ptz_os_version_id)
+endif()
+
 set(CPACK_GENERATOR "DEB")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "${PLUGIN_EMAIL}")


### PR DESCRIPTION
The published .deb previously only targeted whichever Ubuntu version built it (ubuntu-24.04), whose Qt6 packages carry the "t64" ABI transition suffix (e.g. libqt6gui6t64). Installing that package on a system without the same transition failed with unsatisfiable dependencies, since the non-suffixed libqt6gui6 etc. aren't interchangeable with the t64 packages from dpkg's point of view.

Add ubuntu-22.04 and ubuntu-26.04 to the release build matrix alongside ubuntu-24.04, and add the matching variants to the release job's artifact list so all three actually reach the GitHub Release instead of just sitting in CI artifacts.

Tag CPACK_PACKAGE_FILE_NAME with the build machine's distro/version (read from /etc/os-release) so the three .deb builds get distinct file names instead of silently overwriting each other under the same name when collected into the release.


Assisted-by: Claude:claude-sonnet-5