### PR TITLE
Save config via obs_frontend_add_save_callback instead of on exit only

### DIFF
--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -91,6 +91,16 @@ void PTZControls::onFrontendEvent(enum obs_frontend_event event, void *ptr)
 	controls->handleFrontendEvent(event);
 }
 
+void PTZControls::onFrontendSaveEvent(obs_data_t *save_data, bool saving, void *ptr)
+{
+	/* This plugin's configuration lives in its own file rather than the
+	 * scene collection's save_data, so only the "saving" direction is of
+	 * interest here; loading still happens once at startup in LoadConfig() */
+	Q_UNUSED(save_data);
+	if (saving)
+		reinterpret_cast<PTZControls *>(ptr)->SaveConfig();
+}
+
 void PTZControls::handleFrontendEvent(enum obs_frontend_event event)
 {
 	switch (event) {
@@ -123,11 +133,13 @@ void PTZControls::handleFrontendEvent(enum obs_frontend_event event)
 		updateMoveControls();
 		break;
 	case OBS_FRONTEND_EVENT_EXIT:
-		/* OBS is shutting down. Save the configuration and remove the PTZDevice instances */
-		SaveConfig();
+		/* OBS is shutting down. It has already run its own save pass (and
+		 * so has called onFrontendSaveEvent()) as part of its shutdown
+		 * sequence, so just remove the PTZDevice instances here */
 		while (!hotkeys.isEmpty())
 			obs_hotkey_unregister(hotkeys.takeFirst());
 		obs_frontend_remove_event_callback(onFrontendEvent, this);
+		obs_frontend_remove_save_callback(onFrontendSaveEvent, this);
 		ptzDeviceList.delete_all();
 		break;
 	default:
@@ -207,6 +219,7 @@ PTZControls::PTZControls(QWidget *parent) : QFrame(parent), ui(new Ui::PTZContro
 	ui->pantiltStack->installEventFilter(filter);
 
 	obs_frontend_add_event_callback(onFrontendEvent, this);
+	obs_frontend_add_save_callback(onFrontendSaveEvent, this);
 
 	hide();
 

--- a/src/ptz-controls.hpp
+++ b/src/ptz-controls.hpp
@@ -40,6 +40,7 @@ private:
 	static PTZControls *instance;
 	static void onFrontendEvent(enum obs_frontend_event event, void *ptr);
 	void handleFrontendEvent(enum obs_frontend_event event);
+	static void onFrontendSaveEvent(obs_data_t *save_data, bool saving, void *ptr);
 
 	std::unique_ptr<Ui::PTZControls> ui;
 	TouchControl *pantilt_widget;

--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <obs.hpp>
+#include <algorithm>
 #include "ptz-device.hpp"
 #include "ptz-list-model.hpp"
 #include "ptz.h"
@@ -263,8 +264,10 @@ void PTZDevice::update(OBSData config)
 {
 	getDefaults(config);
 
+	/* Clamp to the same range enforced by the properties slider; a corrupt
+	 * or hand-edited config must not yield an absurd preset count. */
+	m_maxPresets = std::clamp<size_t>(obs_data_get_int(config, "preset_max"), 1, 128);
 	/* Update the list of preset names */
-	m_maxPresets = (size_t)obs_data_get_int(config, "preset_max");
 	OBSDataArrayAutoRelease preset_array = obs_data_get_array(config, "presets");
 	m_presets.clear();
 	m_presetsDisplayOrder.clear();


### PR DESCRIPTION
Previously SaveConfig() only ran from the OBS_FRONTEND_EVENT_EXIT handler, so any change made during a session was lost if OBS terminated abnormally (crash, kill) instead of exiting cleanly.

Register onFrontendSaveEvent via obs_frontend_add_save_callback and call SaveConfig() whenever OBS invokes it with saving == true. OBS fires this callback reactively whenever something meaningful changes (scene/source edits, output start/stop, scene collection switch) and once more as part of its own ordered shutdown sequence, before OBS_FRONTEND_EVENT_EXIT is even dispatched - so the explicit SaveConfig() call in that handler is now redundant and removed; it just unregisters both callbacks and tears down devices.

Fixes #285

Assisted-by: Claude:claude-sonnet-5