### PR TITLE
PROPOSAL: relicense remaining src/ files to GPLv2+

### DIFF
--- a/src/circularlistview.cpp
+++ b/src/circularlistview.cpp
@@ -1,3 +1,10 @@
+/* Circular list view widget
+ *
+ * Copyright 2023 Grant Likely <grant.likely@secretlab.ca>
+ *
+ * SPDX-License-Identifier: GPLv2+
+ */
+
 #include <QListView>
 #include "circularlistview.hpp"
 

--- a/src/circularlistview.hpp
+++ b/src/circularlistview.hpp
@@ -1,3 +1,9 @@
+/* Circular list view widget
+ *
+ * Copyright 2023 Grant Likely <grant.likely@secretlab.ca>
+ *
+ * SPDX-License-Identifier: GPLv2+
+ */
 #pragma once
 #include <QListView>
 

--- a/src/protocol-helpers.cpp
+++ b/src/protocol-helpers.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020-2022 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 
 #include <QMap>

--- a/src/protocol-helpers.hpp
+++ b/src/protocol-helpers.hpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020-2022 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 #pragma once
 

--- a/src/ptz-action-source.c
+++ b/src/ptz-action-source.c
@@ -2,7 +2,7 @@
  *
  * Copyright 2021 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  *
  * This file implements an OBS source plugin that triggers PTZ device actions,
  * like recalling a preset or initiating a camera move.

--- a/src/ptz-controls.cpp
+++ b/src/ptz-controls.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 
 #include <obs-module.h>

--- a/src/ptz-controls.hpp
+++ b/src/ptz-controls.hpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 #pragma once
 

--- a/src/ptz-device.cpp
+++ b/src/ptz-device.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020-2026 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 
 #include <obs.hpp>

--- a/src/ptz-device.hpp
+++ b/src/ptz-device.hpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020-2026 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 #pragma once
 

--- a/src/ptz-list-model.cpp
+++ b/src/ptz-list-model.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020-2026 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 
 #include <obs.hpp>

--- a/src/ptz-list-model.hpp
+++ b/src/ptz-list-model.hpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020-2026 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 #pragma once
 

--- a/src/ptz-onvif.cpp
+++ b/src/ptz-onvif.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2022 Jonatã Bolzan Loss <jonata@jonata.org>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  *
  * ONVIF support is experimental and needs rework to be non-blocking before it
  * can be enabled generically. This code is disabled by default. To use it

--- a/src/ptz-onvif.hpp
+++ b/src/ptz-onvif.hpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2022 Jonatã Bolzan Loss <jonata@jonata.org>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 #pragma once
 

--- a/src/ptz-pelco.cpp
+++ b/src/ptz-pelco.cpp
@@ -3,7 +3,7 @@
  * Copyright 2021 Luuk Verhagen <developer@verhagenluuk.nl>
  * Copyright 2020-2021 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 
 #include "ptz-pelco.hpp"

--- a/src/ptz-pelco.hpp
+++ b/src/ptz-pelco.hpp
@@ -3,7 +3,7 @@
  * Copyright 2021 Luuk Verhagen <developer@verhagenluuk.nl>
  * Copyright 2020-2021 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 
 #pragma once

--- a/src/ptz-usb-cam.cpp
+++ b/src/ptz-usb-cam.cpp
@@ -2,7 +2,7 @@
 	*
 	* Copyright 2025 Fabio Ferrari <fabio.ferrar@gmail.com>
 	*
-	* SPDX-License-Identifier: GPLv2
+	* SPDX-License-Identifier: GPLv2+
 	*/
 
 #include <qt-wrappers.hpp>

--- a/src/ptz-usb-cam.hpp
+++ b/src/ptz-usb-cam.hpp
@@ -2,7 +2,7 @@
 	*
 	* Copyright 2025 Fabio Ferrari <fabioferrari@gmail.com>
 	*
-	* SPDX-License-Identifier: GPLv2
+	* SPDX-License-Identifier: GPLv2+
 	*/
 #pragma once
 

--- a/src/ptz-visca-tcp.cpp
+++ b/src/ptz-visca-tcp.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2021 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 
 #include <qt-wrappers.hpp>

--- a/src/ptz-visca-tcp.hpp
+++ b/src/ptz-visca-tcp.hpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2021 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 #pragma once
 

--- a/src/ptz-visca-uart.cpp
+++ b/src/ptz-visca-uart.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2021 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 
 #include <qt-wrappers.hpp>

--- a/src/ptz-visca-uart.hpp
+++ b/src/ptz-visca-uart.hpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2021 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 #pragma once
 

--- a/src/ptz-visca-udp.cpp
+++ b/src/ptz-visca-udp.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2021 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 
 #include <QHostInfo>

--- a/src/ptz-visca-udp.hpp
+++ b/src/ptz-visca-udp.hpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2021 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 #pragma once
 

--- a/src/ptz-visca.cpp
+++ b/src/ptz-visca.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 
 #include <qt-wrappers.hpp>

--- a/src/ptz-visca.hpp
+++ b/src/ptz-visca.hpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 #pragma once
 

--- a/src/ptz.c
+++ b/src/ptz.c
@@ -2,7 +2,7 @@
  *
  * Copyright 2020 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  *
  * Module initialization and utility routines for OBS
  */

--- a/src/ptz.h
+++ b/src/ptz.h
@@ -2,7 +2,7 @@
  *
  * Copyright 2020 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  *
  * Module initialization and utility routines for OBS
  */

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,3 +1,10 @@
+/* Pan Tilt Zoom settings window
+ *
+ * Copyright 2020 Grant Likely <grant.likely@secretlab.ca>
+ *
+ * SPDX-License-Identifier: GPLv2+
+ */
+
 #include <QPlainTextEdit>
 #include <QComboBox>
 #include <QHBoxLayout>

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 #pragma once
 

--- a/src/touch-control.cpp
+++ b/src/touch-control.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 
 #include <QWidget>

--- a/src/touch-control.hpp
+++ b/src/touch-control.hpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2023 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 #pragma once
 

--- a/src/uart-wrapper.cpp
+++ b/src/uart-wrapper.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2021 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 
 #include <QSerialPortInfo>

--- a/src/uart-wrapper.hpp
+++ b/src/uart-wrapper.hpp
@@ -2,7 +2,7 @@
  *
  * Copyright 2020-2022 Grant Likely <grant.likely@secretlab.ca>
  *
- * SPDX-License-Identifier: GPLv2
+ * SPDX-License-Identifier: GPLv2+
  */
 #pragma once
 


### PR DESCRIPTION
This is a proposal to change the license of the project from GPLv2 to GPLv2-or-later. For context, this project started as GPLv2 only based on my own preferences, but OBS Studio has always been GPLv2-or-later. The license change proposal is to allow static linking against some LGPLv3 code.

Updates the SPDX-License-Identifier on 18 files from GPLv2 to GPLv2+, and adds a header to settings.cpp, which has never had one in its history (it was implicitly covered by the repository's default GPLv2 LICENSE file).

The change requires approval from developers who hold copyright on the source files, as listed here:

  Jonatã Bolzan Loss  712 lines across 12 files
  Fabio Ferrari        605 lines across 7 files
  Norihiro Kamae       452 lines across 7 files
  Eddy Weiz             35 lines across 4 files
  Jason Lanclos         10 lines across 1 file
  Luuk Verhagen          9 lines across 2 files
  BitRate27              7 lines across 1 file

Please respond to this change with an "Acked-by:" tag if you agree to the change.


Assisted-by: Claude:claude-sonnet-5