### PR TITLE
Enhance ubuntu builds

### DIFF
--- a/.github/scripts/package-ubuntu
+++ b/.github/scripts/package-ubuntu
@@ -160,6 +160,20 @@ ${_usage_host:-}"
     pushd ${project_root}
     cmake --build build_${target##*-} --config ${config} -t package ${cmake_args}
     popd
+
+    log_group "Fixing up the obs-studio dependency..."
+    # Rewrite the auto-detected libobs* dependency to obs-studio instead,
+    # keeping whatever minimum version dpkg-shlibdeps derived - a plain
+    # libobs dependency is unsatisfiable when OBS Studio came from the
+    # obsproject PPA rather than the distro archive.
+    local deb
+    for deb (${project_root}/release/*.deb) {
+      local workdir=$(mktemp -d)
+      dpkg-deb -R ${deb} ${workdir}
+      sed -i -E 's/\blibobs[A-Za-z0-9.+-]* \(/obs-studio (/' ${workdir}/DEBIAN/control
+      dpkg-deb -b ${workdir} ${deb}
+      rm -rf ${workdir}
+    }
   } else {
     log_group "Archiving ${product_name}..."
     local output_name="${product_name}-${product_version}-${target##*-}-ubuntu-gnu"

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -247,7 +247,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-${{ matrix.target }}-${{ needs.check-event.outputs.commitHash }}
-          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.target }}*.*
+          path: |
+            ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}*${{ steps.setup.outputs.pluginVersion }}*.deb
+            ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}*${{ steps.setup.outputs.pluginVersion }}*.ddeb
+            ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.target }}*.tar.xz
 
       - uses: actions/cache/save@v5
         if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -249,13 +249,6 @@ jobs:
           name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-${{ matrix.target }}-${{ needs.check-event.outputs.commitHash }}
           path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.target }}*.*
 
-      - name: Upload debug symbol artifacts 🪲
-        uses: actions/upload-artifact@v7
-        if: ${{ fromJSON(needs.check-event.outputs.package) }}
-        with:
-          name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-${{ matrix.target }}-${{ needs.check-event.outputs.commitHash }}-dbgsym
-          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.target }}*-dbgsym.ddeb
-
       - uses: actions/cache/save@v5
         if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
         with:

--- a/cmake/linux/defaults.cmake
+++ b/cmake/linux/defaults.cmake
@@ -15,24 +15,20 @@ set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL TRUE)
 set(CPACK_PACKAGE_NAME "${CMAKE_PROJECT_NAME}")
 set(CPACK_PACKAGE_VERSION "${CMAKE_PROJECT_VERSION}")
 
-# For Linux, work out the distro version so it can be included in the
-# release filename. Falls back to the old name if the file isn't there
-# (e.g. a minimal container).
-set(_pkg_distro_suffix "")
+# Use the Debian Policy-compliant name_version_arch.deb naming (DEB-DEFAULT),
+# with the distro codename folded into the version as a "~" suffix (the
+# convention Ubuntu PPAs use)
+# Falls back to the bare version if /etc/os-release isn't there
+set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
 if(EXISTS "/etc/os-release")
-  file(STRINGS "/etc/os-release" _os_release_id REGEX "^ID=")
-  file(STRINGS "/etc/os-release" _os_release_version_id REGEX "^VERSION_ID=")
-  if(_os_release_id AND _os_release_version_id)
-    string(REGEX REPLACE "^ID=\"?([^\"]*)\"?$" "\\1" _os_id "${_os_release_id}")
-    string(REGEX REPLACE "^VERSION_ID=\"?([^\"]*)\"?$" "\\1" _os_version_id "${_os_release_version_id}")
-    set(_pkg_distro_suffix "-${_os_id}${_os_version_id}")
+  file(STRINGS "/etc/os-release" _os_release_codename REGEX "^VERSION_CODENAME=")
+  if(_os_release_codename)
+    string(REGEX REPLACE "^VERSION_CODENAME=\"?([^\"]*)\"?$" "\\1" _os_codename "${_os_release_codename}")
+    set(CPACK_DEBIAN_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION}~${_os_codename}")
   endif()
 endif()
 
-set(
-  CPACK_PACKAGE_FILE_NAME
-  "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_C_LIBRARY_ARCHITECTURE}${_pkg_distro_suffix}"
-)
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CMAKE_C_LIBRARY_ARCHITECTURE}")
 
 set(CPACK_GENERATOR "DEB")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)


### PR DESCRIPTION
Several updates and changes to the Ubuntu builds
- Removes non-effective artifact upload
- Makes the .dep packages depend on obs-studio instead of libobs so they work with both distro packages and the OBS Project PPA
- Adopts Ubuntu package naming convention.